### PR TITLE
Increase resiliency of ArgumentFormatter for certain inputs

### DIFF
--- a/Sdk/ArgumentFormatter.cs
+++ b/Sdk/ArgumentFormatter.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace Xunit.Sdk
@@ -83,6 +84,7 @@ namespace Xunit.Sdk
             var stringParameter = value as string;
             if (stringParameter != null)
             {
+                stringParameter = EscapeHexChars(stringParameter);
                 stringParameter = stringParameter.Replace(@"""", @"\""");
                 if (stringParameter.Length > MAX_STRING_LENGTH)
                     return string.Format("\"{0}\"...", new object[] { stringParameter.Substring(0, MAX_STRING_LENGTH) });
@@ -225,6 +227,31 @@ namespace Xunit.Sdk
 
                 ex = tiex.InnerException;
             }
+        }
+        
+        static string EscapeHexChars(string s)
+        {
+            var builder = new StringBuilder(s.Length);
+            for (int i = 0; i < s.Length; i++)
+            {
+                char ch = s[i];
+                if (ch < 32) // C0 control char
+                    builder.AppendFormat(@"\x{0}", (+ch).ToString("x2"));
+                else if (char.IsSurrogatePair(s, i)) // should handle the case of ch being the last one
+                {
+                    // For valid surrogates, append like normal
+                    builder.Append(ch);
+                    builder.Append(s[++i]);
+                }
+                // Check for stray surrogates/other invalid chars
+                else if (char.IsSurrogate(ch) || ch == '\uFFFE' || ch == '\uFFFF')
+                {
+                    builder.AppendFormat(@"\x{0}", (+ch).ToString("x4"));
+                }
+                else
+                    builder.Append(ch); // Append the char like normal
+            }
+            return builder.ToString();
         }
     }
 }

--- a/Sdk/ArgumentFormatter.cs
+++ b/Sdk/ArgumentFormatter.cs
@@ -63,6 +63,14 @@ namespace Xunit.Sdk
             if (value is char)
             {
                 var charValue = (char)value;
+                
+                if (charValue == '\'')
+                    return @"'\''";
+                if (charValue == '\t')
+                    return @"'\t'";
+                if (charValue == '\n')
+                    return @"'\n'";
+                
                 if (char.IsLetterOrDigit(charValue) || char.IsPunctuation(charValue) || char.IsSymbol(charValue) || charValue == ' ')
                     return string.Format("'{0}'", new object[] { value });
 
@@ -75,6 +83,7 @@ namespace Xunit.Sdk
             var stringParameter = value as string;
             if (stringParameter != null)
             {
+                stringParameter = stringParameter.Replace(@"""", @"\""");
                 if (stringParameter.Length > MAX_STRING_LENGTH)
                     return string.Format("\"{0}\"...", new object[] { stringParameter.Substring(0, MAX_STRING_LENGTH) });
 


### PR DESCRIPTION
Migrated from xunit/xunit#804 where I fixed these changes in `XmlTestExecutionVisitor`.

This PR introduces the following changes:
- For characters, `\'` is now returned for single quotes, `\t` for tabs, and `\n` for newlines.
- Double quotes are escaped as well if the parameter is a string.
- If a control/invalid character is detected, it is converted to hex.

Unfortunately I wasn't able to test (or even build) this locally since assert.xunit is a Git submodule, but I did my best to be careful while typing. (I'll also submit a PR to the main repo adding such tests once this is merged.)

cc: @bradwilson 
