### PR TITLE
PropertyChangedEventArgs.PropertyName == null/string.Empty not working.

### DIFF
--- a/PropertyAsserts.cs
+++ b/PropertyAsserts.cs
@@ -23,7 +23,7 @@ namespace Xunit
 
             bool propertyChangeHappened = false;
 
-            PropertyChangedEventHandler handler = (sender, args) => propertyChangeHappened |= propertyName.Equals(args.PropertyName, StringComparison.OrdinalIgnoreCase);
+            PropertyChangedEventHandler handler = (sender, args) => propertyChangeHappened |= string.IsNullOrEmpty(args.PropertyName) || propertyName.Equals(args.PropertyName, StringComparison.OrdinalIgnoreCase);
 
             @object.PropertyChanged += handler;
 
@@ -60,7 +60,7 @@ namespace Xunit
 
             bool propertyChangeHappened = false;
 
-            PropertyChangedEventHandler handler = (sender, args) => propertyChangeHappened |= propertyName.Equals(args.PropertyName, StringComparison.OrdinalIgnoreCase);
+            PropertyChangedEventHandler handler = (sender, args) => propertyChangeHappened |= string.IsNullOrEmpty(args.PropertyName) || propertyName.Equals(args.PropertyName, StringComparison.OrdinalIgnoreCase);
 
             @object.PropertyChanged += handler;
 


### PR DESCRIPTION
`PropertyChangedEventArgs.PropertyName == null/string.Empty` indicates that all properties have been changed. 

See the remarkssection [here](https://msdn.microsoft.com/en-us/library/system.componentmodel.inotifypropertychanged.propertychanged%28v=vs.110%29.aspx)

But this is not working for the actual `Assert.PropertyChanged`.

This PR is fixing this wrong behaviour.
