### PR TITLE
Improve equality comparisons for equal objects of different types

### DIFF
--- a/Sdk/AssertEqualityComparer.cs
+++ b/Sdk/AssertEqualityComparer.cs
@@ -48,23 +48,27 @@ namespace Xunit.Sdk
             }
 
             // Same type?
+            bool sameType = true;
             if (!skipTypeCheck && x.GetType() != y.GetType())
-                return false;
+                sameType = false;
 
-            // Implements IEquatable<T>?
-            var equatable = x as IEquatable<T>;
-            if (equatable != null)
-                return equatable.Equals(y);
+            if (sameType)
+            {
+                // Implements IEquatable<T>?
+                var equatable = x as IEquatable<T>;
+                if (equatable != null)
+                    return equatable.Equals(y);
 
-            // Implements IComparable<T>?
-            var comparableGeneric = x as IComparable<T>;
-            if (comparableGeneric != null)
-                return comparableGeneric.CompareTo(y) == 0;
+                // Implements IComparable<T>?
+                var comparableGeneric = x as IComparable<T>;
+                if (comparableGeneric != null)
+                    return comparableGeneric.CompareTo(y) == 0;
 
-            // Implements IComparable?
-            var comparable = x as IComparable;
-            if (comparable != null)
-                return comparable.CompareTo(y) == 0;
+                // Implements IComparable?
+                var comparable = x as IComparable;
+                if (comparable != null)
+                    return comparable.CompareTo(y) == 0;
+            }
 
             // Dictionaries?
             var dictionariesEqual = CheckIfDictionariesAreEqual(x, y);


### PR DESCRIPTION
Fixes xunit/xunit#752
Fixes xunit/xunit#992
Fixes xunit/xunit#509

These are semantically equivilent, but xunit didn't report them as such. This PR allows these cases

```
[Fact]
public void Equivilence_IReadOnlyCollection()
{
    var expected = new string[] { "foo", "bar" };
    var actual = (IReadOnlyCollection<string>)new ReadOnlyCollection<string>(expected);

    Assert.Equal(expected, actual);
    Assert.Throws<NotEqualException>(() => Assert.NotEqual(expected, actual));
}

[Fact]
public void Equivilence_DifferentArrays()
{
    var expected = new string[] { "foo", "bar" };
    var actual = new object[] { "foo", "bar" };

    Assert.Equal(expected, actual);
    Assert.Throws<NotEqualException>(() => Assert.NotEqual(expected, actual));
}
```

/cc @bradwilson @attilah
