### PR TITLE
Assert.All now includes the item in the failure messages

### DIFF
--- a/CollectionAsserts.cs
+++ b/CollectionAsserts.cs
@@ -26,7 +26,7 @@ namespace Xunit
             Assert.GuardArgumentNotNull("collection", collection);
             Assert.GuardArgumentNotNull("action", action);
 
-            var errors = new Stack<Tuple<int, Exception>>();
+            var errors = new Stack<Tuple<int, object, Exception>>();
             var array = collection.ToArray();
 
             for (var idx = 0; idx < array.Length; ++idx)
@@ -37,7 +37,7 @@ namespace Xunit
                 }
                 catch (Exception ex)
                 {
-                    errors.Push(new Tuple<int, Exception>(idx, ex));
+                    errors.Push(new Tuple<int, object, Exception>(idx, array[idx], ex));
                 }
             }
 

--- a/Sdk/Exceptions/AllException.cs
+++ b/Sdk/Exceptions/AllException.cs
@@ -15,7 +15,7 @@ namespace Xunit.Sdk
 #endif
     class AllException : XunitException
     {
-        readonly IReadOnlyList<Tuple<int, Exception>> errors;
+        readonly IReadOnlyList<Tuple<int, object, Exception>> errors;
         readonly int totalItems;
 
         /// <summary>
@@ -23,7 +23,7 @@ namespace Xunit.Sdk
         /// </summary>
         /// <param name="totalItems">The total number of items that were in the collection.</param>
         /// <param name="errors">The list of errors that occurred during the test pass.</param>
-        public AllException(int totalItems, Tuple<int, Exception>[] errors)
+        public AllException(int totalItems, Tuple<int, object, Exception>[] errors)
             : base("Assert.All() Failure")
         {
             this.errors = errors;
@@ -33,7 +33,7 @@ namespace Xunit.Sdk
         /// <summary>
         /// The errors that occurred during execution of the test.
         /// </summary>
-        public IReadOnlyList<Exception> Failures { get { return errors.Select(t => t.Item2).ToList(); } }
+        public IReadOnlyList<Exception> Failures { get { return errors.Select(t => t.Item3).ToList(); } }
 
         /// <inheritdoc/>
         public override string Message
@@ -45,7 +45,12 @@ namespace Xunit.Sdk
                     var indexString = string.Format(CultureInfo.CurrentCulture, "[{0}]: ", error.Item1);
                     var spaces = Environment.NewLine + "".PadRight(indexString.Length);
 
-                    return indexString + error.Item2.ToString().Replace(Environment.NewLine, spaces);
+                    return string.Format(CultureInfo.CurrentCulture,
+                                         "{0}Item: {1}{2}{3}",
+                                         indexString,
+                                         error.Item2.ToString().Replace(Environment.NewLine, spaces),
+                                         spaces,
+                                         error.Item3.ToString().Replace(Environment.NewLine, spaces));
                 });
 
                 return string.Format(CultureInfo.CurrentCulture,


### PR DESCRIPTION
Implements xunit/xunit#1000
Since the message has changed, the corresponding test also needs to change. I have done this in xunit/xunit#1017

Assert.All now includes the failed item in the failure message:
Old print message:
```
Assert.All() Failure: 1 out of 5 items in the collection did not pass.
[1]: System.Exception: Multi-line
     message
```

New print message:
```
Assert.All() Failure: 1 out of 5 items in the collection did not pass.
[1]: Item: ToString-call on the failed item.
     System.Exception: Multi-line
     message
```