### PR TITLE
Ensure that different ranked arrays and lengths are never equal

### DIFF
--- a/Sdk/AssertEqualityComparer.cs
+++ b/Sdk/AssertEqualityComparer.cs
@@ -83,7 +83,34 @@ namespace Xunit.Sdk
             // Enumerable?
             var enumerablesEqual = CheckIfEnumerablesAreEqual(x, y);
             if (enumerablesEqual.HasValue)
-                return enumerablesEqual.GetValueOrDefault();
+            {
+                if (!enumerablesEqual.GetValueOrDefault())
+                {
+                    return false;
+                }
+
+                // Array.GetEnumerator() flattens out the array, ignoring array ranks and lengths
+                Array xArray = x as Array;
+                Array yArray = y as Array;
+                if (xArray != null && yArray != null)
+                {
+                    // new object[2,1] != new object[2]
+                    if (xArray.Rank != yArray.Rank)
+                    {
+                        return false;
+                    }
+
+                    // new object[2,1] != new object[1,2]
+                    for (int i = 0; i < xArray.Rank; i++)
+                    {
+                        if (xArray.GetLength(i) != yArray.GetLength(i))
+                        {
+                            return false;
+                        }
+                    }
+                }
+                return true;
+            }
 
             // Last case, rely on object.Equals
             return object.Equals(x, y);


### PR DESCRIPTION
The different ranked array fix is an oversight from #6

The different length array fix is a reported bug: fixes https://github.com/xunit/xunit/issues/907