### PR TITLE
Fix Assert.Equals for IComparable type with different types

### DIFF
--- a/Sdk/AssertEqualityComparer.cs
+++ b/Sdk/AssertEqualityComparer.cs
@@ -63,11 +63,22 @@ namespace Xunit.Sdk
                 var comparableGeneric = x as IComparable<T>;
                 if (comparableGeneric != null)
                     return comparableGeneric.CompareTo(y) == 0;
+            }
 
-                // Implements IComparable?
-                var comparable = x as IComparable;
-                if (comparable != null)
+            // Implements IComparable?
+            var comparable = x as IComparable;
+            if (comparable != null)
+            {
+                try
+                {
                     return comparable.CompareTo(y) == 0;
+                }
+                catch
+                {
+                    // Some implementations of IComparable.CompareTo throw exceptions in
+                    // certain situations, such as if x can't compare against y.
+                    // If this happens, just swallow up the exception and continue comparing.
+                }
             }
 
             // Dictionaries?


### PR DESCRIPTION
The following test cases are now supported. Before, they would return false. Now they correctly return true.

```
[Fact]
public void Comparable_NonGeneric_DifferentType_Equal()
{
    var expected = new MultiComparable(1);
    var actual = 1;
    
    Assert.Equal(expected, (IComparable)actual);
    Assert.Equal(expected, (object)actual);
}

[Fact]
public void Comparable_NonGeneric_DifferentType_NotEqual()
{
    var expected = new MultiComparable(1);
    var actual = 2;
    
    Assert.NotEqual(expected, (IComparable)actual);
    Assert.NotEqual(expected, (object)actual);
}

class MultiComparable : IComparable
{
    private int Value { get; }

    public MultiComparable(int value)
    {
        Value = value;
    }

    public int CompareTo(object obj)
    {
        if (obj is int)
        {
            return Value.CompareTo(obj);
        }
        else if (obj is MultiComparable)
        {
            return Value.CompareTo(((MultiComparable)obj).Value);
        }

        throw new InvalidOperationException();
    }
}
```