### PR TITLE
Fix xunit/xunit#1206 by reordering equality criteria in AssertEqualityComparer

### DIFF
--- a/Sdk/AssertEqualityComparer.cs
+++ b/Sdk/AssertEqualityComparer.cs
@@ -14,7 +14,6 @@ namespace Xunit.Sdk
     class AssertEqualityComparer<T> : IEqualityComparer<T>
     {
         static readonly IEqualityComparer DefaultInnerComparer = new AssertEqualityComparerAdapter<object>(new AssertEqualityComparer<object>());
-        static readonly TypeInfo NullableTypeInfo = typeof(Nullable<>).GetTypeInfo();
 
         readonly Func<IEqualityComparer> innerComparerFactory;
 
@@ -31,17 +30,23 @@ namespace Xunit.Sdk
         /// <inheritdoc/>
         public bool Equals(T x, T y)
         {
-            var typeInfo = typeof(T).GetTypeInfo();
-
             // Null?
-            if (!typeInfo.IsValueType || (typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition().GetTypeInfo().IsAssignableFrom(NullableTypeInfo)))
+            if (typeof(T).IsReferenceOrNullableType())
             {
-                if (object.Equals(x, default(T)))
-                    return object.Equals(y, default(T));
+                if (x == null)
+                    return y == null;
 
-                if (object.Equals(y, default(T)))
+                if (y == null)
                     return false;
             }
+
+            // IMPORTANT: The user's notion of equality takes priority over xUnit's notion of equality.
+            // All methods the user can use to signal that (s)he thinks two objects are/aren't equal, e.g.
+            // by implementing equatable/comparable interfaces, or overriding object.Equals, should be
+            // picked up on first before comparing the objects in ways the user can't control.
+            // For example, if x and y are two collections with contents [1, 2] and [3, 4] but the user
+            // has overridden Equals on them to say that they are equal, then we will agree with the user
+            // although the collections have different contents.
 
             // Implements IEquatable<T>?
             var equatable = x as IEquatable<T>;
@@ -80,13 +85,53 @@ namespace Xunit.Sdk
                 }
             }
 
+            // object.Equals is either supplied by the user or not overridden.
+            // - If it's supplied by the user, then whatever it returns is definitive.
+            // - If it's not overridden, then it is definitive if it returns true (that means the objects are reference-equal),
+            //   but undefinitive if it returns false (two different arrays having the same contents are considered equal).
+            // So we only pay attention to the result if it's true.
+            if (object.Equals(x, y))
+            {
+                return true;
+            }
+            
+            // Implements IStructuralEquatable?
+            var structuralEquatable = x as IStructuralEquatable;
+            if (structuralEquatable != null && structuralEquatable.Equals(y, new TypeErasedEqualityComparer(innerComparerFactory())))
+                return true;
+
+            // Implements IEquatable<typeof(y)>?
+            Type iequatableY = y.GetType().MakeEquatableType();
+            if (iequatableY.IsAssignableFrom(x.GetType()))
+            {
+                MethodInfo equalsMethod = iequatableY.GetDeclaredMethod(nameof(IEquatable<T>.Equals));
+                return equalsMethod.Invoke<bool>(x, y);
+            }
+
+            // Implements IComparable<typeof(y)>?
+            Type icomparableY = y.GetType().MakeComparableType();
+            if (icomparableY.IsAssignableFrom(x.GetType()))
+            {
+                MethodInfo compareToMethod = icomparableY.GetDeclaredMethod(nameof(IComparable<T>.CompareTo));
+                try
+                {
+                    return compareToMethod.Invoke<int>(x, y) == 0;
+                }
+                catch
+                {
+                    // Some implementations of IComparable.CompareTo throw exceptions in
+                    // certain situations, such as if x can't compare against y.
+                    // If this happens, just swallow up the exception and continue comparing.
+                }
+            }
+
             // Dictionaries?
             var dictionariesEqual = CheckIfDictionariesAreEqual(x, y);
             if (dictionariesEqual.HasValue)
                 return dictionariesEqual.GetValueOrDefault();
 
             // Sets?
-            var setsEqual = CheckIfSetsAreEqual(x, y, typeInfo);
+            var setsEqual = CheckIfSetsAreEqual(x, y);
             if (setsEqual.HasValue)
                 return setsEqual.GetValueOrDefault();
 
@@ -99,61 +144,39 @@ namespace Xunit.Sdk
                     return false;
                 }
 
-                // Array.GetEnumerator() flattens out the array, ignoring array ranks and lengths
-                Array xArray = x as Array;
-                Array yArray = y as Array;
-                if (xArray != null && yArray != null)
+                // Array.GetEnumerator() flattens out the array, ignoring array ranks and lengths.
+                // Arrays with different shapes could have been compared as equal when they aren't.
+                return CheckIfArrayShapesAreEqual(x, y) ?? true;
+            }
+            
+            return false;
+        }
+
+        bool? CheckIfArrayShapesAreEqual(T x, T y)
+        {
+            Array xArray = x as Array;
+            Array yArray = y as Array;
+            if (xArray != null && yArray != null)
+            {
+                // new object[2,1] != new object[2]
+                if (xArray.Rank != yArray.Rank)
                 {
-                    // new object[2,1] != new object[2]
-                    if (xArray.Rank != yArray.Rank)
+                    return false;
+                }
+
+                // new object[2,1] != new object[1,2]
+                for (int i = 0; i < xArray.Rank; i++)
+                {
+                    if (xArray.GetLength(i) != yArray.GetLength(i))
                     {
                         return false;
                     }
-
-                    // new object[2,1] != new object[1,2]
-                    for (int i = 0; i < xArray.Rank; i++)
-                    {
-                        if (xArray.GetLength(i) != yArray.GetLength(i))
-                        {
-                            return false;
-                        }
-                    }
                 }
+
                 return true;
             }
-            
-            // Implements IStructuralEquatable?
-            var structuralEquatable = x as IStructuralEquatable;
-            if (structuralEquatable != null && structuralEquatable.Equals(y, new TypeErasedEqualityComparer(innerComparerFactory())))
-                return true;
 
-            // Implements IEquatable<typeof(y)>?
-            TypeInfo iequatableY = typeof(IEquatable<>).MakeGenericType(y.GetType()).GetTypeInfo();
-            if (iequatableY.IsAssignableFrom(x.GetType().GetTypeInfo()))
-            {
-                MethodInfo equalsMethod = iequatableY.GetDeclaredMethod(nameof(IEquatable<T>.Equals));
-                return (bool)equalsMethod.Invoke(x, new object[] { y });
-            }
-
-            // Implements IComparable<typeof(y)>?
-            TypeInfo icomparableY = typeof(IComparable<>).MakeGenericType(y.GetType()).GetTypeInfo();
-            if (icomparableY.IsAssignableFrom(x.GetType().GetTypeInfo()))
-            {
-                MethodInfo compareToMethod = icomparableY.GetDeclaredMethod(nameof(IComparable<T>.CompareTo));
-                try
-                {
-                    return (int)compareToMethod.Invoke(x, new object[] { y }) == 0;
-                }
-                catch
-                {
-                    // Some implementations of IComparable.CompareTo throw exceptions in
-                    // certain situations, such as if x can't compare against y.
-                    // If this happens, just swallow up the exception and continue comparing.
-                }
-            }
-
-            // Last case, rely on object.Equals
-            return object.Equals(x, y);
+            return null;
         }
 
         bool? CheckIfEnumerablesAreEqual(T x, T y)
@@ -227,9 +250,9 @@ namespace Xunit.Sdk
 
         private static MethodInfo s_compareTypedSetsMethod;
 
-        bool? CheckIfSetsAreEqual(T x, T y, TypeInfo typeInfo)
+        bool? CheckIfSetsAreEqual(T x, T y)
         {
-            if (!IsSet(typeInfo))
+            if (!typeof(T).IsSet())
                 return null;
 
             var enumX = x as IEnumerable;
@@ -247,7 +270,7 @@ namespace Xunit.Sdk
                 s_compareTypedSetsMethod = GetType().GetTypeInfo().GetDeclaredMethod(nameof(CompareTypedSets));
 
             MethodInfo method = s_compareTypedSetsMethod.MakeGenericMethod(new Type[] { elementType });
-            return (bool)method.Invoke(this, new object[] { enumX, enumY });
+            return method.Invoke<bool>(this, enumX, enumY);
         }
 
         bool CompareTypedSets<R>(IEnumerable enumX, IEnumerable enumY)
@@ -255,15 +278,6 @@ namespace Xunit.Sdk
             var setX = new HashSet<R>(enumX.Cast<R>());
             var setY = new HashSet<R>(enumY.Cast<R>());
             return setX.SetEquals(setY);
-        }
-
-        bool IsSet(TypeInfo typeInfo)
-        {
-            return typeInfo.ImplementedInterfaces
-                .Select(i => i.GetTypeInfo())
-                .Where(ti => ti.IsGenericType)
-                .Select(ti => ti.GetGenericTypeDefinition())
-                .Contains(typeof(ISet<>).GetGenericTypeDefinition());
         }
 
         /// <inheritdoc/>

--- a/Sdk/ReflectionExtensions.cs
+++ b/Sdk/ReflectionExtensions.cs
@@ -19,11 +19,15 @@ namespace Xunit.Sdk
             return type.GetTypeInfo().IsAssignableFrom(otherType.GetTypeInfo());
         }
 
-        public static bool IsReferenceOrNullableType(this Type type)
+        public static bool IsNullable(this Type type)
         {
             var typeInfo = type.GetTypeInfo();
-            return !typeInfo.IsValueType ||
-                (typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition().GetTypeInfo().IsAssignableFrom(NullableTypeInfo));
+            return typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition().GetTypeInfo().IsAssignableFrom(NullableTypeInfo);
+        }
+
+        public static bool IsReferenceTypeOrNullable(this Type type)
+        {
+            return !type.GetTypeInfo().IsValueType || type.IsNullable();
         }
 
         public static bool IsSet(this Type type)

--- a/Sdk/ReflectionExtensions.cs
+++ b/Sdk/ReflectionExtensions.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Xunit.Sdk
+{
+    static class ReflectionExtensions
+    {
+        static readonly TypeInfo NullableTypeInfo = typeof(Nullable<>).GetTypeInfo();
+
+        public static TResult Invoke<TResult>(this MethodBase method, object @this, params object[] parameters)
+        {
+            return (TResult)method.Invoke(@this, parameters);
+        }
+
+        public static bool IsAssignableFrom(this Type type, Type otherType)
+        {
+            return type.GetTypeInfo().IsAssignableFrom(otherType.GetTypeInfo());
+        }
+
+        public static bool IsReferenceOrNullableType(this Type type)
+        {
+            var typeInfo = type.GetTypeInfo();
+            return !typeInfo.IsValueType ||
+                (typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition().GetTypeInfo().IsAssignableFrom(NullableTypeInfo));
+        }
+
+        public static bool IsSet(this Type type)
+        {
+            var implementedInterfaces = type.GetTypeInfo().ImplementedInterfaces.Select(i => i.GetTypeInfo());
+            var genericInterfaces = implementedInterfaces.Where(ti => ti.IsGenericType);
+            return genericInterfaces.Any(ti => ti.GetGenericTypeDefinition() == typeof(ISet<>));
+        }
+
+        public static Type MakeComparableType(this Type comparandType)
+        {
+            return typeof(IComparable<>).MakeGenericType(comparandType);
+        }
+
+        public static Type MakeEquatableType(this Type comparandType)
+        {
+            return typeof(IEquatable<>).MakeGenericType(comparandType);
+        }
+    }
+}


### PR DESCRIPTION
Warning: Do not merge yet, I haven't figured out how to build the code and even if it compiles it's likely to break some tests.

This PR fixes xunit/xunit#1206 by changing the algorithm to determine equality in `AssertEqualityComparer`. Before, we were calling `object.Equals` as a last resort; now, we call it right after checking for IEquatable/IComparable, *but* we only pay attention if it returns true. The rationale is:

- If the user thinks 2 objects are equal, that takes priority over if xUnit thinks 2 objects are equal. This means that if the user has implemented any equatable/comparable interfaces or overridden `Equals` on the object, we try to pick up on that before doing dictionary/set/enumerable comparison.
  - The resulting behavior is if 2 collection types have different contents, but the user's `Equals` override says they're equal, we listen to the user.

- If `object.Equals` returns true, then we consider the 2 objects definitely equal. However if it's false, there's a broad category of potential reasons why the objects weren't considered equal, so it's still very possible they could be considered equal by some other criteria.
  - For example, `object.Equals` may return false because two collections aren't reference-equal or don't have the same type, but they should still be considered equal if they have the same contents.

Also included in this PR is a lot of refactoring for `AssertEqualityComparer`. I moved much of the reflection-related stuff into a new class.

/cc @bradwilson, @hughbe