### PR TITLE
Performance tweak for Assert.Single: Early terminate if possible.

### DIFF
--- a/CollectionAsserts.cs
+++ b/CollectionAsserts.cs
@@ -345,26 +345,13 @@ namespace Xunit
             int count = 0;
             T result = default(T);
 
-            T item;
-            var enumerator = collection.GetEnumerator();
-            try
-            {
-                while(enumerator.MoveNext())
+            foreach (T item in collection)
+                if (predicate(item))
                 {
-                    item = enumerator.Current;
-                    if (predicate(item))
-                    {
-                        ++count;
-                        if (count > 1)
-                            break;
-                        result = item;
-                    }
+                    if (++count > 1)
+                        break;
+                    result = item;
                 }
-            }
-            finally
-            {
-                (enumerator as IDisposable)?.Dispose();
-            }
 
             switch (count)
             {

--- a/CollectionAsserts.cs
+++ b/CollectionAsserts.cs
@@ -366,8 +366,12 @@ namespace Xunit
                 (enumerator as IDisposable)?.Dispose();
             }
 
-            if (count != 1)
-                throw new SingleException(count);
+            switch (count)
+            {
+                case 0: throw SingleException.Empty();
+                case 1: break;
+                default: throw SingleException.MoreThanOne();
+            }
 
             return result;
         }

--- a/CollectionAsserts.cs
+++ b/CollectionAsserts.cs
@@ -345,12 +345,26 @@ namespace Xunit
             int count = 0;
             T result = default(T);
 
-            foreach (T item in collection)
-                if (predicate(item))
+            T item;
+            var enumerator = collection.GetEnumerator();
+            try
+            {
+                while(enumerator.MoveNext())
                 {
-                    result = item;
-                    ++count;
+                    item = enumerator.Current;
+                    if (predicate(item))
+                    {
+                        ++count;
+                        if (count > 1)
+                            break;
+                        result = item;
+                    }
                 }
+            }
+            finally
+            {
+                (enumerator as IDisposable)?.Dispose();
+            }
 
             if (count != 1)
                 throw new SingleException(count);

--- a/Sdk/Exceptions/AssertCollectionCountException.cs
+++ b/Sdk/Exceptions/AssertCollectionCountException.cs
@@ -13,7 +13,7 @@ namespace Xunit.Sdk
     class AssertCollectionCountException : XunitException
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="SingleException"/> class.
+        /// Initializes a new instance of the <see cref="AssertCollectionCountException"/> class.
         /// </summary>
         /// <param name="expectedCount">The expected number of items in the collection.</param>
         /// <param name="actualCount">The actual number of items in the collection.</param>

--- a/Sdk/Exceptions/SingleException.cs
+++ b/Sdk/Exceptions/SingleException.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Exception thrown when the collection did not contain exactly one element.
     /// </summary>
-#if XUNIT_VISIBILITY_INTERNAL 
+#if XUNIT_VISIBILITY_INTERNAL
     internal
 #else
     public
@@ -14,10 +14,10 @@
         /// Initializes a new instance of the <see cref="SingleException"/> class.
         /// </summary>
         private SingleException(string errorMessage) : base(errorMessage) { }
-        
+
         public static SingleException Empty() =>
             new SingleException("The collection was expected to contain a single element, but it was empty.");
-        
+
         public static SingleException MoreThanOne() =>
             new SingleException("The collection was expected to contain a single element, but it contained more than one element.");
     }

--- a/Sdk/Exceptions/SingleException.cs
+++ b/Sdk/Exceptions/SingleException.cs
@@ -8,12 +8,17 @@
 #else
     public
 #endif
-    class SingleException : AssertCollectionCountException
+    class SingleException : XunitException
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SingleException"/> class.
         /// </summary>
-        /// <param name="count">The numbers of items in the collection.</param>
-        public SingleException(int count) : base(1, count) { }
+        private SingleException(string errorMessage) : base(errorMessage) { }
+        
+        public static SingleException Empty() =>
+            new SingleException("The collection was expected to contain a single element, but it was empty.");
+        
+        public static SingleException MoreThanOne() =>
+            new SingleException("The collection was expected to contain a single element, but it contained more than one element.");
     }
 }


### PR DESCRIPTION
I am sure it is not necessary to enumerate through a collection to determine what Assert.Single is supposed to determine: **whether the collection contains 0 or at least 2 items (matching an optional predicate)**.

As soon as the second match is found the enumeration can be terminated. If the collection is big (or even worse: lazy evaluated infinite enumerator :O ) my tweak will considerably speed up the execution of Assert.Single().

I use the same try/finally pattern I saw in Assert.Empty and Assert.NotEmpty to keep the consistency and handle exception thrown by Enumerator.MoveNext() (for example CollectionWasModifiedException).