### PR TITLE
Modified EmptyException to output with Expected and Actual details

### DIFF
--- a/Sdk/Exceptions/EmptyException.cs
+++ b/Sdk/Exceptions/EmptyException.cs
@@ -11,29 +11,14 @@ namespace Xunit.Sdk
 #else
     public
 #endif
-    class EmptyException : XunitException
+    class EmptyException : AssertActualExpectedException
     {
         /// <summary>
         /// Creates a new instance of the <see cref="EmptyException"/> class.
         /// </summary>
         public EmptyException(IEnumerable collection)
-            : base("Assert.Empty() Failure")
+            : base("<empty>", ArgumentFormatter.Format(collection), "Assert.Empty() Failure")
         {
-            Collection = collection;
-        }
-
-        /// <summary>
-        /// The collection that failed the test.
-        /// </summary>
-        public IEnumerable Collection { get; }
-
-        /// <inheritdoc/>
-        public override string Message
-        {
-            get
-            {
-                return $"{base.Message}{Environment.NewLine}Collection: {ArgumentFormatter.Format(Collection)}";
-            }
         }
     }
 }


### PR DESCRIPTION
Fixes xunit/xunit#1806.
Modified EmptyException to output the Message with Expected and Actual details. Changed EmptyException class to inherit from AssertActualExpectedException class to achieve it. (#1806)