### PR TITLE
Include more information in Assert.Single failure messages

### DIFF
--- a/CollectionAsserts.cs
+++ b/CollectionAsserts.cs
@@ -385,9 +385,7 @@ namespace Xunit
             GetSingleResult(collection.Cast<object>(), item => object.Equals(item, expected), ArgumentFormatter.Format(expected), out Exception toThrow);
 
             if (toThrow != null)
-            {
                 throw toThrow;
-            }
         }
 
         /// <summary>
@@ -406,9 +404,7 @@ namespace Xunit
             T result = GetSingleResult(collection, null, null, out Exception toThrow);
 
             if (toThrow != null)
-            {
                 throw toThrow;
-            }
 
             return result;
         }

--- a/Sdk/Exceptions/SingleException.cs
+++ b/Sdk/Exceptions/SingleException.cs
@@ -1,4 +1,6 @@
-﻿namespace Xunit.Sdk
+﻿using System;
+
+namespace Xunit.Sdk
 {
     /// <summary>
     /// Exception thrown when the collection did not contain exactly one element.
@@ -16,16 +18,23 @@
         private SingleException(string errorMessage) : base(errorMessage) { }
 
         /// <summary>
-        /// Creates an instance of <see cref="SingleException"/> for when the collection was empty.
+        /// Creates an instance of <see cref="SingleException"/> for when the collection didn't contain any of the expected value.
         /// </summary>
-        public static SingleException Empty() =>
-            new SingleException("The collection was expected to contain a single element, but it was empty.");
+        public static Exception Empty(string expected) =>
+            new SingleException("The collection was expected to contain a single element" +
+                (expected == null ? "" : " matching " + expected) +
+                ", but it " +
+                (expected == null ? "was empty." : "contained no matching elements."));
 
         /// <summary>
-        /// Creates an instance of <see cref="SingleException"/> for when the collection had too many items.
+        /// Creates an instance of <see cref="SingleException"/> for when the collection had too many of the expected items.
         /// </summary>
         /// <returns></returns>
-        public static SingleException MoreThanOne() =>
-            new SingleException("The collection was expected to contain a single element, but it contained more than one element.");
+        public static Exception MoreThanOne(int count, string expected) =>
+            new SingleException("The collection was expected to contain a single element" +
+                (expected == null ? "" : " matching " + expected) +
+                ", but it contained " + count + " " +
+                (expected == null ? "" : "matching ") + 
+                "elements.");
     }
 }


### PR DESCRIPTION
I noticed that when using a predicate on Assert.Single the error message said "empty" for non empty collections, which was confusing. Then I found https://github.com/xunit/xunit/issues/1351 and thought that covered it.

Best way to see the new messages would be to look at the tests, here: https://github.com/xunit/xunit/pull/1837