### PR TITLE
Add Assert.Default<T>(T t) and Assert.NotDefault<T>(T t).

### DIFF
--- a/DefaultAsserts.cs
+++ b/DefaultAsserts.cs
@@ -1,0 +1,36 @@
+using Xunit.Sdk;
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+    internal
+#else
+    public
+#endif
+    partial class Assert
+    {
+        /// <summary>
+        /// Verifies that an object is the default value for its type.
+        /// </summary>
+        /// <param name="t">The object to be inspected</param>
+        /// <typeparam name="T">The type of the object to be inspected</typeparam>
+        /// <exception cref="DefaultException">Thrown when the object is not the default value</exception>
+        public static void Default<T>(T t)
+        {
+            if (t != default(T))
+                throw new DefaultException(t);
+        }
+
+        /// <summary>
+        /// Verifies that an object is not the default value for its type.
+        /// </summary>
+        /// <param name="t">The object to be inspected</param>
+        /// <typeparam name="T">The type of the object to be inspected</typeparam>
+        /// <exception cref="NotDefaultException">Thrown when the object is the default value</exception>
+        public static void NotDefault<T>(T t)
+        {
+            if (t == default(T))
+                throw new NotDefaultException(t);
+        }
+    }
+}

--- a/Sdk/Exceptions/DefaultException.cs
+++ b/Sdk/Exceptions/DefaultException.cs
@@ -1,0 +1,21 @@
+namespace Xunit.Sdk
+{
+    /// <summary>
+    /// Exception thrown when an object reference is unexpectedly not default.
+    /// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+    internal
+#else
+    public
+#endif
+    class DefaultException : AssertActualExpectedException
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="DefaultException"/> class.
+        /// </summary>
+        /// <param name="actual"></param>
+        public DefaultException(object actual)
+            : base(null, actual, "Assert.Default() Failure")
+        { }
+    }
+}

--- a/Sdk/Exceptions/NotDefaultException.cs
+++ b/Sdk/Exceptions/NotDefaultException.cs
@@ -1,0 +1,21 @@
+namespace Xunit.Sdk
+{
+    /// <summary>
+    /// Exception thrown when an object reference is unexpectedly default.
+    /// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+    internal
+#else
+    public
+#endif
+    class NotDefaultException : AssertActualExpectedException
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="NotDefaultException"/> class.
+        /// </summary>
+        /// <param name="actual"></param>
+        public NotDefaultException(object actual)
+            : base(null, actual, "Assert.NotDefault() Failure")
+        { }
+    }
+}


### PR DESCRIPTION
Allows for checking if a generic variable contains a `default(T)` value.