### PR TITLE
fix 994 and fix 1924

### DIFF
--- a/Sdk/Exceptions/EqualException.cs
+++ b/Sdk/Exceptions/EqualException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
@@ -38,13 +39,28 @@ namespace Xunit.Sdk
         }
 
         /// <summary>
+        /// Creates a new instance of the <see cref="EqualException"/> class for IEnumerable comparisons.
+        /// </summary>
+        /// <param name="expected">The expected object value</param>
+        /// <param name="actual">The actual object value</param>
+        /// <param name="mismatchIndex">The first index in the expected IEnumerable where the strings differ</param>
+        public EqualException(IEnumerable expected, IEnumerable actual, int mismatchIndex)
+            : base(CreateIEnumerableMessage(expected, mismatchIndex, out int? pointerPositionExpected),
+                  CreateIEnumerableMessage(actual, mismatchIndex, out int? pointerPositionActual), "Assert.Equal() Failure")
+        {
+            ActualIndex = mismatchIndex;
+            ExpectedIndex = mismatchIndex;
+            PointerPosition = (pointerPositionExpected ?? -1) > (pointerPositionActual ?? -1) ? pointerPositionExpected : pointerPositionActual;
+        }
+
+        /// <summary>
         /// Creates a new instance of the <see cref="EqualException"/> class for string comparisons.
         /// </summary>
         /// <param name="expected">The expected string value</param>
         /// <param name="actual">The actual string value</param>
         /// <param name="expectedIndex">The first index in the expected string where the strings differ</param>
         /// <param name="actualIndex">The first index in the actual string where the strings differ</param>
-        public EqualException(string expected, string actual, int expectedIndex, int actualIndex)
+        public EqualException(object expected, object actual, int expectedIndex, int actualIndex)
             : base(expected, actual, "Assert.Equal() Failure")
         {
             ActualIndex = actualIndex;
@@ -63,6 +79,11 @@ namespace Xunit.Sdk
         /// </summary>
         public int ExpectedIndex { get; private set; }
 
+        /// <summary>
+        /// Gets the index of the difference between the IEunmerables when converted to a string.
+        /// </summary>
+        public int? PointerPosition { get; private set; }
+
         /// <inheritdoc/>
         public override string Message
         {
@@ -80,12 +101,21 @@ namespace Xunit.Sdk
             if (ExpectedIndex == -1)
                 return base.Message;
 
-            Tuple<string, string> printedExpected = ShortenAndEncode(Expected, ExpectedIndex, '↓');
-            Tuple<string, string> printedActual = ShortenAndEncode(Actual, ActualIndex, '↑');
+            Tuple<string, string> printedExpected = ShortenAndEncode(Expected, PointerPosition ?? ExpectedIndex, '↓', ExpectedIndex);
+            Tuple<string, string> printedActual = ShortenAndEncode(Actual, PointerPosition ?? ActualIndex, '↑', ActualIndex);
+
+            StringBuilder toFormat = new StringBuilder();
+            toFormat.Append("{1}{0}");
+            if (!string.IsNullOrWhiteSpace(printedExpected.Item2))
+                toFormat.Append("          {2}{0}");
+            toFormat.Append("Expected: {3}{0}");
+            toFormat.Append("Actual:   {4}");
+            if (!string.IsNullOrWhiteSpace(printedActual.Item2))
+                toFormat.Append("{0}          {5}");
 
             return string.Format(
                 CultureInfo.CurrentCulture,
-                "{1}{0}          {2}{0}Expected: {3}{0}Actual:   {4}{0}          {5}",
+                toFormat.ToString(),
                 Environment.NewLine,
                 UserMessage,
                 printedExpected.Item2,
@@ -95,8 +125,9 @@ namespace Xunit.Sdk
             );
         }
 
-        static Tuple<string, string> ShortenAndEncode(string value, int position, char pointer)
+        static Tuple<string, string> ShortenAndEncode(string value, int position, char pointer, int? index = null)
         {
+            index = index ?? position;
             int start = Math.Max(position - 20, 0);
             int end = Math.Min(position + 41, value.Length);
             var printedValue = new StringBuilder(100);
@@ -125,16 +156,22 @@ namespace Xunit.Sdk
                 if (idx < position)
                     printedPointer.Append(' ', paddingLength);
                 else if (idx == position)
-                    printedPointer.AppendFormat("{0} (pos {1})", pointer, position);
+                    printedPointer.AppendFormat("{0} (pos {1})", pointer, index);
             }
 
             if (value.Length == position)
-                printedPointer.AppendFormat("{0} (pos {1})", pointer, position);
+                printedPointer.AppendFormat("{0} (pos {1})", pointer, index);
 
             if (end < value.Length)
                 printedValue.Append("···");
 
             return new Tuple<string, string>(printedValue.ToString(), printedPointer.ToString());
         }
+
+        static object CreateIEnumerableMessage(object value, int mismatchIndex, out int? pointerPosition)
+        {
+            return ArgumentFormatter.Format(value, out pointerPosition, mismatchIndex);
+        }
+
     }
 }


### PR DESCRIPTION
Fixes for issues 994 and 1924
fix 994
fix 1924

These fixes addresses changing IEnumerable Equals asserts to allow error messages to point to the location in an array where the first mismatch is found. Additionally,  appropriate leading and trailing ellipses are made on the collection to show only a relevant number of surrounding values (as defined by MAX_ENUMERABLE_LENGTH).
In order to not break existing patterns there is a fair amount of type inspection done to only take action in appropriate scenarios. I also added nullable parameters to support keeping method footprints reverse compatible without over-enlarging the code base. This solution ended up a bit more ugly than I expected, but it is effective and doesn't seem to have performance impacts. All existing and new unit tests pass successfully. 
Please also see the associated pull request to the main repository, which contains the unit tests.