### PR TITLE
Assert.Equal with ignoreWhiteSpace = true improvements

### DIFF
--- a/StringAsserts.cs
+++ b/StringAsserts.cs
@@ -3,6 +3,7 @@
 #endif
 
 using System;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using Xunit.Sdk;
 
@@ -309,7 +310,22 @@ namespace Xunit
 
 		static bool IsLineEnding(char c) => c == '\r' || c == '\n';
 
-		static bool IsWhiteSpace(char c) => c == ' ' || c == '\t';
+		static bool IsWhiteSpace(char c)
+		{
+			const char mongolianVowelSeparator = '\u180E';
+			const char zeroWidthSpace = '\u200B';
+			const char zeroWidthNoBreakSpace = '\uFEFF';
+			const char tabulation = '\u0009';
+
+			var unicodeCategory = CharUnicodeInfo.GetUnicodeCategory(c);
+
+			return
+				unicodeCategory == UnicodeCategory.SpaceSeparator ||
+				c == mongolianVowelSeparator ||
+				c == zeroWidthSpace ||
+				c == zeroWidthNoBreakSpace ||
+				c == tabulation;
+		}
 
 		static int SkipLineEnding(string value, int index)
 		{
@@ -326,16 +342,10 @@ namespace Xunit
 		{
 			while (index < value.Length)
 			{
-				switch (value[index])
-				{
-					case ' ':
-					case '\t':
-						index++;
-						break;
-
-					default:
-						return index;
-				}
+				if (IsWhiteSpace(value[index]))
+					index++;
+				else
+					return index;
 			}
 
 			return index;


### PR DESCRIPTION
Assert.Equal with ignoreWhiteSpace = true will now ignore

SPACE (U+0020)
NO-BREAK SPACE (U+00A0)
OGHAM SPACE MARK (U+1680)
MONGOLIAN VOWEL SEPARATOR (U+180E)
EN QUAD (U+2000)
EM QUAD (U+2001)
EN SPACE (U+2002)
EM SPACE (U+2003)
THREE-PER-EM SPACE (U+2004)
FOUR-PER-EM SPACE (U+2005)
SIX-PER-EM SPACE (U+2006)
FIGURE SPACE (U+2007)
PUNCTUATION SPACE (U+2008)
THIN SPACE (U+2009)
HAIR SPACE (U+200A)
ZERO WIDTH SPACE (U+200B)
NARROW NO-BREAK SPACE (U+202F)
MEDIUM MATHEMATICAL SPACE (U+205F)
IDEOGRAPHIC SPACE (U+3000)
ZERO WIDTH NO-BREAK SPACE (U+FEFF)
TABULATION \u0009

As per [#1931](https://github.com/xunit/xunit/issues/1931).