### PR TITLE
Make constructor receiving inner exception public

### DIFF
--- a/Sdk/Exceptions/XunitException.cs
+++ b/Sdk/Exceptions/XunitException.cs
@@ -33,7 +33,7 @@ namespace Xunit.Sdk
         /// </summary>
         /// <param name="userMessage">The user message to be displayed</param>
         /// <param name="innerException">The inner exception</param>
-        protected XunitException(string userMessage, Exception innerException)
+        public XunitException(string userMessage, Exception innerException)
             : base(userMessage, innerException)
         {
             UserMessage = userMessage;


### PR DESCRIPTION
Some mocking libraries (i.e. JustMock) throw unit testing framework specific exceptions so that 
the mock verification exceptions integrate better with the test framework. 

By making this constructor public, we make it easier for them to integrate by allowing direct 
creation passing the inner mocking library exception in the constructor. Note that this constructor 
is public in the `Exception` base class, so it's not unusal for derived classes to also expose it 
publicly. Also, since the `XunitException` is not abstract, it makes sense to allow it to be created 
with the same ctor args as any other public exception type.

This would avoid having to jump through hoops to invoke it, like what [JustMock does](https://github.com/telerik/JustMockLite/blob/master/Telerik.JustMock/Core/Context/XUnitMockingContextResolver.cs#L46-L66) 
creating a derived class just to pass in the inner exception. Note how [none of that is needed](https://github.com/telerik/JustMockLite/tree/master/Telerik.JustMock/Core/Context) 
for any of the other test frameworks.