### PR TITLE
Added Assert.Distinct method

### DIFF
--- a/CollectionAsserts.cs
+++ b/CollectionAsserts.cs
@@ -313,6 +313,32 @@ namespace Xunit
 		}
 
 		/// <summary>
+		/// Verifies that a collection contains each object only once.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be compared</typeparam>
+		/// <param name="collection">The collection to be inspected</param>
+		/// <param name="comparer">The comparer used to equate objects in the collection with the expected object</param>
+		/// <exception cref="DoesNotContainException">Thrown when the object is present inside the container</exception>
+		public static void Distinct<T>(
+			IEnumerable<T> collection,
+#if XUNIT_NULLABLE
+			IEqualityComparer<T>? comparer = null
+#else
+			IEqualityComparer<T> comparer = null
+#endif		
+		)
+		{
+			Assert.GuardArgumentNotNull(nameof(collection), collection);
+
+			var set = new HashSet<T>(comparer ?? EqualityComparer<T>.Default);
+			foreach (var x in collection)
+			{
+				if (!set.Add(x))
+					throw new ContainsDuplicateException(x, collection);
+			}
+		}
+
+		/// <summary>
 		/// Verifies that a collection does not contain a given object.
 		/// </summary>
 		/// <typeparam name="T">The type of the object to be compared</typeparam>

--- a/CollectionAsserts.cs
+++ b/CollectionAsserts.cs
@@ -317,25 +317,29 @@ namespace Xunit
 		/// </summary>
 		/// <typeparam name="T">The type of the object to be compared</typeparam>
 		/// <param name="collection">The collection to be inspected</param>
-		/// <param name="comparer">The comparer used to equate objects in the collection with the expected object</param>
-		/// <exception cref="DoesNotContainException">Thrown when the object is present inside the container</exception>
-		public static void Distinct<T>(
-			IEnumerable<T> collection,
-#if XUNIT_NULLABLE
-			IEqualityComparer<T>? comparer = null
-#else
-			IEqualityComparer<T> comparer = null
-#endif		
-		)
+		/// <exception cref="DoesNotContainException">Thrown when an object is present inside the container more than once</exception>
+		public static void Distinct<T>(IEnumerable<T> collection)
 		{
-			Assert.GuardArgumentNotNull(nameof(collection), collection);
+			Distinct<T>(collection, EqualityComparer<T>.Default);
+		}
 
-			var set = new HashSet<T>(comparer ?? EqualityComparer<T>.Default);
+		/// <summary>
+		/// Verifies that a collection contains each object only once.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be compared</typeparam>
+		/// <param name="collection">The collection to be inspected</param>
+		/// <param name="comparer">The comparer used to equate objects in the collection with the expected object</param>
+		/// <exception cref="DoesNotContainException">Thrown when an object is present inside the container more than once</exception>
+		public static void Distinct<T>(IEnumerable<T> collection, IEqualityComparer<T> comparer)
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+			GuardArgumentNotNull(nameof(comparer), comparer);
+
+			var set = new HashSet<T>(comparer);
+
 			foreach (var x in collection)
-			{
 				if (!set.Add(x))
 					throw new ContainsDuplicateException(x, collection);
-			}
 		}
 
 		/// <summary>

--- a/Sdk/Exceptions/ContainsDuplicateException.cs
+++ b/Sdk/Exceptions/ContainsDuplicateException.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections;
+using System.Globalization;
+using System.Linq;
+
+namespace Xunit.Sdk
+{
+    /// <summary>
+    /// Exception thrown when an <see cref="Assert.Distinct{T}(System.Collections.Generic.IEnumerable{T}, System.Collections.Generic.IEqualityComparer{T})" /> finds a duplicate entry in the collection
+    /// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+    internal
+#else
+    public
+#endif
+    class ContainsDuplicateException : XunitException
+    {
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="ContainsDuplicateException"/> class.
+        /// </summary>
+        /// <param name="duplicateObject">The object that was present twice in the collection.</param>
+        /// <param name="collection">The collection that was checked for duplicate entries.</param>
+        public ContainsDuplicateException(
+#if XUNIT_NULLABLE
+			object? duplicateObject,
+#else
+			object duplicateObject,
+#endif
+			IEnumerable collection
+		)
+            : base("Assert.Distinct() Failure")
+        {
+            this.DuplicateObject = duplicateObject;
+            this.Collection = collection;
+        }
+
+        /// <summary> The object that was present twice in the collection. </summary>
+#if XUNIT_NULLABLE
+        public object? DuplicateObject { get; }
+#else
+        public object DuplicateObject { get; }
+#endif
+        /// <summary> The collection that was checked for duplicate entries. </summary>
+        public IEnumerable Collection { get; }
+
+        /// <inheritdoc/>
+        public override string Message
+        {
+            get
+            {
+                return string.Format(CultureInfo.CurrentCulture,
+                                     "{0}: The item {1} occurs multiple times in {2}.",
+                                     base.Message,
+                                     ArgumentFormatter.Format(DuplicateObject),
+                                     ArgumentFormatter.Format(Collection));
+            }
+        }
+    }
+}

--- a/Sdk/Exceptions/ContainsDuplicateException.cs
+++ b/Sdk/Exceptions/ContainsDuplicateException.cs
@@ -5,56 +5,56 @@ using System.Linq;
 
 namespace Xunit.Sdk
 {
-    /// <summary>
-    /// Exception thrown when an <see cref="Assert.Distinct{T}(System.Collections.Generic.IEnumerable{T}, System.Collections.Generic.IEqualityComparer{T})" /> finds a duplicate entry in the collection
-    /// </summary>
+	/// <summary>
+	/// Exception thrown when <see cref="Assert.Distinct{T}(System.Collections.Generic.IEnumerable{T})" />
+	/// or <see cref="Assert.Distinct{T}(System.Collections.Generic.IEnumerable{T}, System.Collections.Generic.IEqualityComparer{T})" />
+	/// finds a duplicate entry in the collection
+	/// </summary>
 #if XUNIT_VISIBILITY_INTERNAL
-    internal
+	internal
 #else
-    public
+	public
 #endif
-    class ContainsDuplicateException : XunitException
-    {
+	class ContainsDuplicateException : XunitException
+	{
 
-        /// <summary>
-        /// Creates a new instance of the <see cref="ContainsDuplicateException"/> class.
-        /// </summary>
-        /// <param name="duplicateObject">The object that was present twice in the collection.</param>
-        /// <param name="collection">The collection that was checked for duplicate entries.</param>
-        public ContainsDuplicateException(
+		/// <summary>
+		/// Creates a new instance of the <see cref="ContainsDuplicateException"/> class.
+		/// </summary>
+		/// <param name="duplicateObject">The object that was present twice in the collection.</param>
+		/// <param name="collection">The collection that was checked for duplicate entries.</param>
 #if XUNIT_NULLABLE
-			object? duplicateObject,
+		public ContainsDuplicateException(object? duplicateObject, IEnumerable collection)
 #else
-			object duplicateObject,
+		public ContainsDuplicateException(object duplicateObject, IEnumerable collection)
 #endif
-			IEnumerable collection
-		)
-            : base("Assert.Distinct() Failure")
-        {
-            this.DuplicateObject = duplicateObject;
-            this.Collection = collection;
-        }
+			: base("Assert.Distinct() Failure")
+		{
+			this.DuplicateObject = duplicateObject;
+			this.Collection = collection;
+		}
 
-        /// <summary> The object that was present twice in the collection. </summary>
+		/// <summary>
+		/// Gets the collection that was checked for duplicate entries.
+		/// </summary>
+		public IEnumerable Collection { get; }
+
+		/// <summary>
+		/// Gets the object that was present more than once in the collection.
+		/// </summary>
 #if XUNIT_NULLABLE
-        public object? DuplicateObject { get; }
+		public object? DuplicateObject { get; }
 #else
-        public object DuplicateObject { get; }
+		public object DuplicateObject { get; }
 #endif
-        /// <summary> The collection that was checked for duplicate entries. </summary>
-        public IEnumerable Collection { get; }
 
-        /// <inheritdoc/>
-        public override string Message
-        {
-            get
-            {
-                return string.Format(CultureInfo.CurrentCulture,
-                                     "{0}: The item {1} occurs multiple times in {2}.",
-                                     base.Message,
-                                     ArgumentFormatter.Format(DuplicateObject),
-                                     ArgumentFormatter.Format(Collection));
-            }
-        }
-    }
+		/// <inheritdoc/>
+		public override string Message
+		{
+			get
+			{
+				return string.Format(CultureInfo.CurrentCulture, "{0}: The item {1} occurs multiple times in {2}.", base.Message, ArgumentFormatter.Format(DuplicateObject), ArgumentFormatter.Format(Collection));
+			}
+		}
+	}
 }


### PR DESCRIPTION
It asserts that all objects in the collection are distinct. It can be emulated by calling `Assert.Equal(collection.Count(), collection.Distinct().Count()`, but the error message is not helpful in that case.

I'm not sure how could I create tests for this function, when it is in a different repository. Should I also open PR there. Also sorry for not open an issue first as I already had the code at hand, we can certainly discuss here.