### PR TITLE
Annotate nullability of Assert.NotNull, Assert.True, Assert.False

### DIFF
--- a/BooleanAsserts.cs
+++ b/BooleanAsserts.cs
@@ -1,4 +1,7 @@
-﻿using Xunit.Sdk;
+﻿#nullable enable
+
+using System.Diagnostics.CodeAnalysis;
+using Xunit.Sdk;
 
 namespace Xunit
 {
@@ -14,7 +17,7 @@ namespace Xunit
         /// </summary>
         /// <param name="condition">The condition to be tested</param>
         /// <exception cref="FalseException">Thrown if the condition is not false</exception>
-        public static void False(bool condition)
+        public static void False([DoesNotReturnIf(parameterValue: true)] bool condition)
         {
             False((bool?)condition, null);
         }
@@ -24,7 +27,7 @@ namespace Xunit
         /// </summary>
         /// <param name="condition">The condition to be tested</param>
         /// <exception cref="FalseException">Thrown if the condition is not false</exception>
-        public static void False(bool? condition)
+        public static void False([DoesNotReturnIf(parameterValue: true)] bool? condition)
         {
             False(condition, null);
         }
@@ -35,7 +38,7 @@ namespace Xunit
         /// <param name="condition">The condition to be tested</param>
         /// <param name="userMessage">The message to show when the condition is not false</param>
         /// <exception cref="FalseException">Thrown if the condition is not false</exception>
-        public static void False(bool condition, string userMessage)
+        public static void False([DoesNotReturnIf(parameterValue: true)] bool condition, string? userMessage)
         {
             False((bool?)condition, userMessage);
         }
@@ -46,7 +49,7 @@ namespace Xunit
         /// <param name="condition">The condition to be tested</param>
         /// <param name="userMessage">The message to show when the condition is not false</param>
         /// <exception cref="FalseException">Thrown if the condition is not false</exception>
-        public static void False(bool? condition, string userMessage)
+        public static void False([DoesNotReturnIf(parameterValue: true)] bool? condition, string? userMessage)
         {
             if (!condition.HasValue || condition.GetValueOrDefault())
                 throw new FalseException(userMessage, condition);
@@ -57,7 +60,7 @@ namespace Xunit
         /// </summary>
         /// <param name="condition">The condition to be inspected</param>
         /// <exception cref="TrueException">Thrown when the condition is false</exception>
-        public static void True(bool condition)
+        public static void True([DoesNotReturnIf(parameterValue: false)] bool condition)
         {
             True((bool?)condition, null);
         }
@@ -67,7 +70,7 @@ namespace Xunit
         /// </summary>
         /// <param name="condition">The condition to be inspected</param>
         /// <exception cref="TrueException">Thrown when the condition is false</exception>
-        public static void True(bool? condition)
+        public static void True([DoesNotReturnIf(parameterValue: false)] bool? condition)
         {
             True(condition, null);
         }
@@ -78,7 +81,7 @@ namespace Xunit
         /// <param name="condition">The condition to be inspected</param>
         /// <param name="userMessage">The message to be shown when the condition is false</param>
         /// <exception cref="TrueException">Thrown when the condition is false</exception>
-        public static void True(bool condition, string userMessage)
+        public static void True([DoesNotReturnIf(parameterValue: false)] bool condition, string? userMessage)
         {
             True((bool?)condition, userMessage);
         }
@@ -89,7 +92,7 @@ namespace Xunit
         /// <param name="condition">The condition to be inspected</param>
         /// <param name="userMessage">The message to be shown when the condition is false</param>
         /// <exception cref="TrueException">Thrown when the condition is false</exception>
-        public static void True(bool? condition, string userMessage)
+        public static void True([DoesNotReturnIf(parameterValue: false)] bool? condition, string? userMessage)
         {
             if (!condition.HasValue || !condition.GetValueOrDefault())
                 throw new TrueException(userMessage, condition);

--- a/BooleanAsserts.cs
+++ b/BooleanAsserts.cs
@@ -1,6 +1,8 @@
-﻿#nullable enable
-
+﻿#if XUNIT_NULLABLE
+#nullable enable
 using System.Diagnostics.CodeAnalysis;
+#endif
+
 using Xunit.Sdk;
 
 namespace Xunit
@@ -17,7 +19,11 @@ namespace Xunit
         /// </summary>
         /// <param name="condition">The condition to be tested</param>
         /// <exception cref="FalseException">Thrown if the condition is not false</exception>
+#if XUNIT_NULLABLE
         public static void False([DoesNotReturnIf(parameterValue: true)] bool condition)
+#else
+        public static void False(bool condition)
+#endif
         {
             False((bool?)condition, null);
         }
@@ -27,7 +33,11 @@ namespace Xunit
         /// </summary>
         /// <param name="condition">The condition to be tested</param>
         /// <exception cref="FalseException">Thrown if the condition is not false</exception>
+#if XUNIT_NULLABLE
         public static void False([DoesNotReturnIf(parameterValue: true)] bool? condition)
+#else
+        public static void False(bool? condition)
+#endif
         {
             False(condition, null);
         }
@@ -38,7 +48,11 @@ namespace Xunit
         /// <param name="condition">The condition to be tested</param>
         /// <param name="userMessage">The message to show when the condition is not false</param>
         /// <exception cref="FalseException">Thrown if the condition is not false</exception>
+#if XUNIT_NULLABLE
         public static void False([DoesNotReturnIf(parameterValue: true)] bool condition, string? userMessage)
+#else
+        public static void False(bool condition, string userMessage)
+#endif
         {
             False((bool?)condition, userMessage);
         }
@@ -49,7 +63,11 @@ namespace Xunit
         /// <param name="condition">The condition to be tested</param>
         /// <param name="userMessage">The message to show when the condition is not false</param>
         /// <exception cref="FalseException">Thrown if the condition is not false</exception>
+#if XUNIT_NULLABLE
         public static void False([DoesNotReturnIf(parameterValue: true)] bool? condition, string? userMessage)
+#else
+        public static void False(bool? condition, string userMessage)
+#endif
         {
             if (!condition.HasValue || condition.GetValueOrDefault())
                 throw new FalseException(userMessage, condition);
@@ -60,7 +78,11 @@ namespace Xunit
         /// </summary>
         /// <param name="condition">The condition to be inspected</param>
         /// <exception cref="TrueException">Thrown when the condition is false</exception>
+#if XUNIT_NULLABLE
         public static void True([DoesNotReturnIf(parameterValue: false)] bool condition)
+#else
+        public static void True(bool condition)
+#endif
         {
             True((bool?)condition, null);
         }
@@ -70,7 +92,11 @@ namespace Xunit
         /// </summary>
         /// <param name="condition">The condition to be inspected</param>
         /// <exception cref="TrueException">Thrown when the condition is false</exception>
+#if XUNIT_NULLABLE
         public static void True([DoesNotReturnIf(parameterValue: false)] bool? condition)
+#else
+        public static void True(bool? condition)
+#endif
         {
             True(condition, null);
         }
@@ -81,7 +107,11 @@ namespace Xunit
         /// <param name="condition">The condition to be inspected</param>
         /// <param name="userMessage">The message to be shown when the condition is false</param>
         /// <exception cref="TrueException">Thrown when the condition is false</exception>
+#if XUNIT_NULLABLE
         public static void True([DoesNotReturnIf(parameterValue: false)] bool condition, string? userMessage)
+#else
+        public static void True(bool condition, string userMessage)
+#endif
         {
             True((bool?)condition, userMessage);
         }
@@ -92,7 +122,11 @@ namespace Xunit
         /// <param name="condition">The condition to be inspected</param>
         /// <param name="userMessage">The message to be shown when the condition is false</param>
         /// <exception cref="TrueException">Thrown when the condition is false</exception>
+#if XUNIT_NULLABLE
         public static void True([DoesNotReturnIf(parameterValue: false)] bool? condition, string? userMessage)
+#else
+        public static void True(bool? condition, string userMessage)
+#endif
         {
             if (!condition.HasValue || !condition.GetValueOrDefault())
                 throw new TrueException(userMessage, condition);

--- a/NullAsserts.cs
+++ b/NullAsserts.cs
@@ -28,7 +28,7 @@ namespace Xunit
         /// </summary>
         /// <param name="object">The object to be inspected</param>
         /// <exception cref="NullException">Thrown when the object reference is not null</exception>
-        public static void Null(object? @object)
+        public static void Null([MaybeNull] object? @object)
         {
             if (@object != null)
                 throw new NullException(@object);

--- a/NullAsserts.cs
+++ b/NullAsserts.cs
@@ -1,6 +1,8 @@
-﻿#nullable enable
-
+﻿#if XUNIT_NULLABLE
+#nullable enable
 using System.Diagnostics.CodeAnalysis;
+#endif
+
 using Xunit.Sdk;
 
 namespace Xunit
@@ -17,7 +19,11 @@ namespace Xunit
         /// </summary>
         /// <param name="object">The object to be validated</param>
         /// <exception cref="NotNullException">Thrown when the object is not null</exception>
+#if XUNIT_NULLABLE
         public static void NotNull([NotNull] object? @object)
+#else
+        public static void NotNull(object @object)
+#endif
         {
             if (@object == null)
                 throw new NotNullException();
@@ -28,7 +34,11 @@ namespace Xunit
         /// </summary>
         /// <param name="object">The object to be inspected</param>
         /// <exception cref="NullException">Thrown when the object reference is not null</exception>
+#if XUNIT_NULLABLE
         public static void Null([MaybeNull] object? @object)
+#else
+        public static void Null(object @object)
+#endif
         {
             if (@object != null)
                 throw new NullException(@object);

--- a/NullAsserts.cs
+++ b/NullAsserts.cs
@@ -1,4 +1,7 @@
-﻿using Xunit.Sdk;
+﻿#nullable enable
+
+using System.Diagnostics.CodeAnalysis;
+using Xunit.Sdk;
 
 namespace Xunit
 {
@@ -14,7 +17,7 @@ namespace Xunit
         /// </summary>
         /// <param name="object">The object to be validated</param>
         /// <exception cref="NotNullException">Thrown when the object is not null</exception>
-        public static void NotNull(object @object)
+        public static void NotNull([NotNull] object? @object)
         {
             if (@object == null)
                 throw new NotNullException();
@@ -25,7 +28,7 @@ namespace Xunit
         /// </summary>
         /// <param name="object">The object to be inspected</param>
         /// <exception cref="NullException">Thrown when the object reference is not null</exception>
-        public static void Null(object @object)
+        public static void Null(object? @object)
         {
             if (@object != null)
                 throw new NullException(@object);

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This project contains the xUnit.net assertion library source code, intended to b
 
 To open an issue for this project, please visit the [core xUnit.net project issue tracker](https://github.com/xunit/xunit/issues).
 
+### Annotations
+
+Projects that consume this repository as source, which are compiled using C# 8 and wish to use nullable reference type annotations should define the `XUNIT_NULLABLE` compilation symbol to opt-in to the relevant nullability analysis annotations on method signatures.
+
 ## About xUnit.net
 
 [<img align="right" width="100px" src="https://dotnetfoundation.org/images/logo_big.svg" />](https://dotnetfoundation.org/projects?type=project&q=xunit)


### PR DESCRIPTION
Part of a fix for both xunit/xunit#2011 and xunit/xunit#2033.

---

By annotating `NotNull`, the C# 8 analyzer will learn, in a nullable context, that usages of the value passed to it after it returns are not `null`. This allows calling code to avoid having to use `!` (null forgiveness operator) on references after validating a reference as non-`null`.

```c#
string? foo = CanReturnNull();

Assert.NotNull(foo);

foo.ToUpper(); // warns here that foo can be null
```

By annotating `NotNull` as in this PR, the warning on the last line does not occur.

---

By annotating `True` and `False` consumers of the assertion APIs don't see warnings in cases like this:

```c#
Assert.True(dic.TryGetValue(key, out var value));
value.DoSomething(); // annotation removes "possible null dereference warning" here
```

---

I also filed PR xunit/xunit#2044 which opts this in at the project level.

(I read the contribution guidelines and see that the associated issue is not flagged as help-wanted. This PR is meant to demonstrate what's required to get this to work, at least on a single Windows machine with VS2019 16.3 installed.)