### PR TITLE
Introduce an assert that allows near-identical DateTimeOffsets to be …

### DIFF
--- a/EqualityAsserts.cs
+++ b/EqualityAsserts.cs
@@ -102,6 +102,29 @@ namespace Xunit
                     ));
             }
         }
+        
+        /// <summary>
+        /// Verifies that two <see cref="DateTimeOffset"/> values are equal, within the precision 
+        /// given by <paramref name="precision"/>.
+        /// </summary>
+        /// <param name="expected">The expected value</param>
+        /// <param name="actual">The value to be compared against</param>
+        /// <param name="precision">The allowed difference in time where the two dates are considered equal</param>
+        /// <exception cref="EqualException">Thrown when the values are not equal</exception>        
+        public static void Equal(DateTimeOffset expected, DateTimeOffset actual, TimeSpan precision)
+        {
+            var difference = (expected - actual).Duration();
+            if (difference > precision)
+            {
+                throw new EqualException(
+                    string.Format(CultureInfo.CurrentCulture, "{0} ", expected),
+                    string.Format(CultureInfo.CurrentCulture, "{0} difference {1} is larger than {2}",
+                        actual,
+                        difference.ToString(),
+                        precision.ToString()
+                    ));
+            }
+        }
 
         /// <summary>
         /// Verifies that two objects are strictly equal, using the type's default comparer.


### PR DESCRIPTION
…considered equal

Extension to https://github.com/xunit/assert.xunit/pull/25 that introduced this functionality for DateTimes.

Added method Assert.Equal(DateTimeOffset, DateTimeOffset, TimeSpan)