### PR TITLE
Adding Span and Memory support: Issue 1966

### DIFF
--- a/MemoryAsserts.cs
+++ b/MemoryAsserts.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿#if XUNIT_NULLABLE
+#nullable enable
+# endif
+
+using System;
+using System.Diagnostics;
 using Xunit.Sdk;
 
 namespace Xunit
@@ -10,14 +15,15 @@ namespace Xunit
 #endif
 	partial class Assert
 	{
-		//NOTE: MemoryAssert logic is dependent on Span asserts. The memory asserts that are not just redirects within the calss use the .span property of memory to perform assertions
+		//NOTE: there is an implicit conversion operator on Memory<T> to ReadOnlyMemory<T> - however, I have found that the compiler sometimes struggles
+		//		with identifying the proper methods to use, thus I have overloaded quite a few of the assertions in terms of supplying both
+		//		Memory and ReadOnlyMemory based methods
 
-		//NOTE: there is an implicit conversion operator on Memory<T> to ReadOnlyMemory<T> I didn't create permutations of all the combinations 
-		//		of Memory and ReadOnlyMemory for each method, but I did create permutations for each argument as a hint to the compiler to help 
-		//		it select the right method.
-
-		//NOTE: we could consider StartsWith<T> and EndsWith<T> with both arguments as ReadOnlyMemory<T>, and use the Memory extension methods to check difference
+		//NOTE: we could consider StartsWith<T> and EndsWith<T> with both arguments as ReadOnlyMemory<T>, and use the Memory extension methods on Span to check difference
 		//		BUT: the current Exceptions for startswith and endswith are only built for string types, so those would need a change (or new non-string versions created).
+
+		//NOTE: Memory and ReadonlyMemory, even when null, are coerced into empty arrays of the specified type when a value is grabbed. Thus some of the code below
+		//		for null scenarios looks odd, but is safe and correct.
 
 		/// <summary>
 		/// Verifies that a Memory contains a given sub-Memory, using the default StringComparison.CurrentCulture comparison type.
@@ -25,7 +31,11 @@ namespace Xunit
 		/// <param name="expectedSubMemory">The sub-Memory expected to be in the Memory</param>
 		/// <param name="actualMemory">The Memory to be inspected</param>
 		/// <exception cref="ContainsException">Thrown when the sub-Memory is not present inside the Memory</exception>
+#if XUNIT_NULLABLE
+		public static void Contains(Memory<char> expectedSubMemory, ReadOnlyMemory<char>? actualMemory)
+#else
 		public static void Contains(Memory<char> expectedSubMemory, ReadOnlyMemory<char> actualMemory)
+#endif
 			=> Contains(expectedSubMemory, actualMemory, StringComparison.CurrentCulture);
 
 		/// <summary>
@@ -34,7 +44,11 @@ namespace Xunit
 		/// <param name="expectedSubMemory">The sub-Memory expected to be in the Memory</param>
 		/// <param name="actualMemory">The Memory to be inspected</param>
 		/// <exception cref="ContainsException">Thrown when the sub-Memory is not present inside the Memory</exception>
+#if XUNIT_NULLABLE
+		public static void Contains(ReadOnlyMemory<char> expectedSubMemory, ReadOnlyMemory<char>? actualMemory)
+#else
 		public static void Contains(ReadOnlyMemory<char> expectedSubMemory, ReadOnlyMemory<char> actualMemory)
+#endif
 			=> Contains(expectedSubMemory, actualMemory, StringComparison.CurrentCulture);
 
 
@@ -45,8 +59,19 @@ namespace Xunit
 		/// <param name="actualMemory">The Memory to be inspected</param>
 		/// <param name="comparisonType">The type of string comparison to perform</param>
 		/// <exception cref="ContainsException">Thrown when the sub-Memory is not present inside the Memory</exception>
+#if XUNIT_NULLABLE
+		public static void Contains(ReadOnlyMemory<char> expectedSubMemory, ReadOnlyMemory<char>? actualMemory, StringComparison comparisonType = StringComparison.CurrentCulture)
+#else
 		public static void Contains(ReadOnlyMemory<char> expectedSubMemory, ReadOnlyMemory<char> actualMemory, StringComparison comparisonType = StringComparison.CurrentCulture)
-			=> Contains(expectedSubMemory.Span, actualMemory.Span, comparisonType);
+#endif
+		{
+			GuardArgumentNotNull(nameof(expectedSubMemory), expectedSubMemory);
+#if XUNIT_NULLABLE
+			Contains(expectedSubMemory.ToString(), actualMemory?.ToString(), comparisonType);//use string comparison for it's strong output
+#else
+			Contains(expectedSubMemory.ToString(), actualMemory.ToString(), comparisonType);//use string comparison for it's strong output
+#endif
+		}
 
 		/// <summary>
 		/// Verifies that a Memory contains a given sub-Memory
@@ -54,8 +79,12 @@ namespace Xunit
 		/// <param name="expectedSubMemory">The sub-Memory expected to be in the Memory</param>
 		/// <param name="actualMemory">The Memory to be inspected</param>
 		/// <exception cref="ContainsException">Thrown when the sub-Memory is not present inside the Memory</exception>
+#if XUNIT_NULLABLE
+		public static void Contains<T>(Memory<T> expectedSubMemory, ReadOnlyMemory<T>? actualMemory) where T : IEquatable<T>
+#else
 		public static void Contains<T>(Memory<T> expectedSubMemory, ReadOnlyMemory<T> actualMemory) where T : IEquatable<T>
-			=> Contains(expectedSubMemory.Span, actualMemory.Span);
+#endif
+			=> ContainsImp(expectedSubMemory, actualMemory);
 
 		/// <summary>
 		/// Verifies that a Memory contains a given sub-Memory
@@ -63,8 +92,27 @@ namespace Xunit
 		/// <param name="expectedSubMemory">The sub-Memory expected to be in the Memory</param>
 		/// <param name="actualMemory">The Memory to be inspected</param>
 		/// <exception cref="ContainsException">Thrown when the sub-Memory is not present inside the Memory</exception>
+#if XUNIT_NULLABLE
+		public static void Contains<T>(ReadOnlyMemory<T> expectedSubMemory, ReadOnlyMemory<T>? actualMemory) where T : IEquatable<T>
+#else
 		public static void Contains<T>(ReadOnlyMemory<T> expectedSubMemory, ReadOnlyMemory<T> actualMemory) where T : IEquatable<T>
-			=> Contains(expectedSubMemory.Span, actualMemory.Span);
+#endif
+			=> ContainsImp(expectedSubMemory, actualMemory);
+
+#if XUNIT_NULLABLE
+		private static void ContainsImp<T>(ReadOnlyMemory<T> expectedSubMemory, ReadOnlyMemory<T>? actualMemory) where T : IEquatable<T>
+#else
+		private static void ContainsImp<T>(ReadOnlyMemory<T> expectedSubMemory, ReadOnlyMemory<T> actualMemory) where T : IEquatable<T>
+#endif
+		{
+			GuardArgumentNotNull(nameof(expectedSubMemory), expectedSubMemory);
+#if XUNIT_NULLABLE
+			if (actualMemory == null || actualMemory.Value.Span.IndexOf(expectedSubMemory.Span) < 0)
+#else
+			if (actualMemory.Span.IndexOf(expectedSubMemory.Span) < 0)
+#endif
+				throw new ContainsException(expectedSubMemory, actualMemory);
+		}
 
 		/// <summary>
 		/// Verifies that a Memory does not contain a given sub-Memory, using the default StringComparison.CurrentCulture comparison type.
@@ -72,7 +120,11 @@ namespace Xunit
 		/// <param name="expectedSubMemory">The sub-Memory expected not to be in the Memory</param>
 		/// <param name="actualMemory">The Memory to be inspected</param>
 		/// <exception cref="DoesNotContainException">Thrown when the sub-Memory is present inside the Memory</exception>
+#if XUNIT_NULLABLE
+		public static void DoesNotContain(Memory<char> expectedSubMemory, ReadOnlyMemory<char>? actualMemory)
+#else
 		public static void DoesNotContain(Memory<char> expectedSubMemory, ReadOnlyMemory<char> actualMemory)
+#endif
 			=> DoesNotContain(expectedSubMemory, actualMemory, StringComparison.CurrentCulture);
 
 		/// <summary>
@@ -81,7 +133,11 @@ namespace Xunit
 		/// <param name="expectedSubMemory">The sub-Memory expected not to be in the Memory</param>
 		/// <param name="actualMemory">The Memory to be inspected</param>
 		/// <exception cref="DoesNotContainException">Thrown when the sub-Memory is present inside the Memory</exception>
+#if XUNIT_NULLABLE
+		public static void DoesNotContain(ReadOnlyMemory<char> expectedSubMemory, ReadOnlyMemory<char>? actualMemory)
+#else
 		public static void DoesNotContain(ReadOnlyMemory<char> expectedSubMemory, ReadOnlyMemory<char> actualMemory)
+#endif
 			=> DoesNotContain(expectedSubMemory, actualMemory, StringComparison.CurrentCulture);
 
 
@@ -92,8 +148,19 @@ namespace Xunit
 		/// <param name="actualMemory">The Memory to be inspected</param>
 		/// <param name="comparisonType">The type of string comparison to perform</param>
 		/// <exception cref="DoesNotContainException">Thrown when the sub-Memory is present inside the Memory</exception>
+#if XUNIT_NULLABLE
+		public static void DoesNotContain(ReadOnlyMemory<char> expectedSubMemory, ReadOnlyMemory<char>? actualMemory, StringComparison comparisonType = StringComparison.CurrentCulture)
+#else
 		public static void DoesNotContain(ReadOnlyMemory<char> expectedSubMemory, ReadOnlyMemory<char> actualMemory, StringComparison comparisonType = StringComparison.CurrentCulture)
-			=> DoesNotContain(expectedSubMemory.Span, actualMemory.Span, comparisonType);
+#endif
+		{
+			GuardArgumentNotNull(nameof(expectedSubMemory), expectedSubMemory);
+#if XUNIT_NULLABLE0
+			DoesNotContain(expectedSubMemory.ToString(), actualMemory?.ToString(), comparisonType);//use string comparison for it's strong output
+#else
+			DoesNotContain(expectedSubMemory.ToString(), actualMemory.ToString(), comparisonType);//use string comparison for it's strong output
+#endif
+		}
 
 		/// <summary>
 		/// Verifies that a Memory does not contain a given sub-Memory
@@ -101,8 +168,12 @@ namespace Xunit
 		/// <param name="expectedSubMemory">The sub-Memory expected not to be in the Memory</param>
 		/// <param name="actualMemory">The Memory to be inspected</param>
 		/// <exception cref="DoesNotContainException">Thrown when the sub-Memory is present inside the Memory</exception>
+#if XUNIT_NULLABLE
+		public static void DoesNotContain<T>(ReadOnlyMemory<T> expectedSubMemory, ReadOnlyMemory<T>? actualMemory) where T : IEquatable<T>
+#else
 		public static void DoesNotContain<T>(ReadOnlyMemory<T> expectedSubMemory, ReadOnlyMemory<T> actualMemory) where T : IEquatable<T>
-			=> DoesNotContain(expectedSubMemory.Span, actualMemory.Span);
+#endif
+			=> DoesNotContainImp(expectedSubMemory, actualMemory);
 
 		/// <summary>
 		/// Verifies that a Memory does not contain a given sub-Memory
@@ -110,8 +181,27 @@ namespace Xunit
 		/// <param name="expectedSubMemory">The sub-Memory expected not to be in the Memory</param>
 		/// <param name="actualMemory">The Memory to be inspected</param>
 		/// <exception cref="DoesNotContainException">Thrown when the sub-Memory is present inside the Memory</exception>
+#if XUNIT_NULLABLE
+		public static void DoesNotContain<T>(Memory<T> expectedSubMemory, ReadOnlyMemory<T>? actualMemory) where T : IEquatable<T>
+#else
 		public static void DoesNotContain<T>(Memory<T> expectedSubMemory, ReadOnlyMemory<T> actualMemory) where T : IEquatable<T>
-			=> DoesNotContain(expectedSubMemory.Span, actualMemory.Span);
+#endif
+			=> DoesNotContainImp(expectedSubMemory, actualMemory);
+
+#if XUNIT_NULLABLE
+		private static void DoesNotContainImp<T>(ReadOnlyMemory<T> expectedSubMemory, ReadOnlyMemory<T>? actualMemory) where T : IEquatable<T>
+#else
+		private static void DoesNotContainImp<T>(ReadOnlyMemory<T> expectedSubMemory, ReadOnlyMemory<T> actualMemory) where T : IEquatable<T>
+#endif
+		{
+			GuardArgumentNotNull(nameof(expectedSubMemory), expectedSubMemory);
+#if XUNIT_NULLABLE
+			if (actualMemory != null && actualMemory.Value.Span.IndexOf(expectedSubMemory.Span) >= 0)
+#else
+			if (actualMemory.Span.IndexOf(expectedSubMemory.Span) >= 0)
+#endif
+				throw new DoesNotContainException(expectedSubMemory, actualMemory);
+		}
 
 		/// <summary>
 		/// Verifies that a Memory starts with a given sub-Memory, using the default StringComparison.CurrentCulture comparison type.
@@ -119,8 +209,12 @@ namespace Xunit
 		/// <param name="expectedStartMemory">The sub-Memory expected to be at the start of the Memory</param>
 		/// <param name="actualMemory">The Memory to be inspected</param>
 		/// <exception cref="StartsWithException">Thrown when the Memory does not start with the expected subMemory</exception>
+#if XUNIT_NULLABLE
+		public static void StartsWith(Memory<char> expectedStartMemory, ReadOnlyMemory<char>? actualMemory)
+#else
 		public static void StartsWith(Memory<char> expectedStartMemory, ReadOnlyMemory<char> actualMemory)
-			=> StartsWith(expectedStartMemory, actualMemory, StringComparison.CurrentCulture);
+#endif
+		=> StartsWith(expectedStartMemory, actualMemory, StringComparison.CurrentCulture);
 
 		/// <summary>
 		/// Verifies that a Memory starts with a given sub-Memory, using the default StringComparison.CurrentCulture comparison type.
@@ -128,7 +222,11 @@ namespace Xunit
 		/// <param name="expectedStartMemory">The sub-Memory expected to be at the start of the Memory</param>
 		/// <param name="actualMemory">The Memory to be inspected</param>
 		/// <exception cref="StartsWithException">Thrown when the Memory does not start with the expected subMemory</exception>
+#if XUNIT_NULLABLE
+		public static void StartsWith(ReadOnlyMemory<char> expectedStartMemory, ReadOnlyMemory<char>? actualMemory)
+#else
 		public static void StartsWith(ReadOnlyMemory<char> expectedStartMemory, ReadOnlyMemory<char> actualMemory)
+#endif
 			=> StartsWith(expectedStartMemory, actualMemory, StringComparison.CurrentCulture);
 
 		/// <summary>
@@ -138,8 +236,19 @@ namespace Xunit
 		/// <param name="actualMemory">The Memory to be inspected</param>
 		/// <param name="comparisonType">The type of string comparison to perform</param>
 		/// <exception cref="StartsWithException">Thrown when the Memory does not start with the expected subMemory</exception>
+#if XUNIT_NULLABLE
+		public static void StartsWith(ReadOnlyMemory<char> expectedStartMemory, ReadOnlyMemory<char>? actualMemory, StringComparison comparisonType = StringComparison.CurrentCulture)
+#else
 		public static void StartsWith(ReadOnlyMemory<char> expectedStartMemory, ReadOnlyMemory<char> actualMemory, StringComparison comparisonType = StringComparison.CurrentCulture)
-			=> StartsWith(expectedStartMemory.Span, actualMemory.Span, comparisonType);
+#endif
+		{
+			GuardArgumentNotNull(nameof(expectedStartMemory), expectedStartMemory);
+#if XUNIT_NULLABLE
+			StartsWith(expectedStartMemory.ToString(), actualMemory?.ToString(), comparisonType);//use string comparison for it's strong output
+#else
+			StartsWith(expectedStartMemory.ToString(), actualMemory.ToString(), comparisonType);//use string comparison for it's strong output
+#endif
+		}
 
 		/// <summary>
 		/// Verifies that a Memory ends with a given sub-Memory, using the default StringComparison.CurrentCulture comparison type.
@@ -147,7 +256,11 @@ namespace Xunit
 		/// <param name="expectedEndMemory">The sub-Memory expected to be at the end of the Memory</param>
 		/// <param name="actualMemory">The Memory to be inspected</param>
 		/// <exception cref="EndsWithException">Thrown when the Memory does not end with the expected subMemory</exception>
+#if XUNIT_NULLABLE
+		public static void EndsWith(Memory<char> expectedEndMemory, ReadOnlyMemory<char>? actualMemory)
+#else
 		public static void EndsWith(Memory<char> expectedEndMemory, ReadOnlyMemory<char> actualMemory)
+#endif
 			=> EndsWith(expectedEndMemory, actualMemory, StringComparison.CurrentCulture);
 
 		/// <summary>
@@ -156,7 +269,11 @@ namespace Xunit
 		/// <param name="expectedEndMemory">The sub-Memory expected to be at the end of the Memory</param>
 		/// <param name="actualMemory">The Memory to be inspected</param>
 		/// <exception cref="EndsWithException">Thrown when the Memory does not end with the expected subMemory</exception>
+#if XUNIT_NULLABLE
+		public static void EndsWith(ReadOnlyMemory<char> expectedEndMemory, ReadOnlyMemory<char>? actualMemory)
+#else
 		public static void EndsWith(ReadOnlyMemory<char> expectedEndMemory, ReadOnlyMemory<char> actualMemory)
+#endif
 			=> EndsWith(expectedEndMemory, actualMemory, StringComparison.CurrentCulture);
 
 		/// <summary>
@@ -166,8 +283,19 @@ namespace Xunit
 		/// <param name="actualMemory">The Memory to be inspected</param>
 		/// <param name="comparisonType">The type of string comparison to perform</param>
 		/// <exception cref="EndsWithException">Thrown when the Memory does not end with the expected subMemory</exception>
+#if XUNIT_NULLABLE
+		public static void EndsWith(ReadOnlyMemory<char> expectedEndMemory, ReadOnlyMemory<char>? actualMemory, StringComparison comparisonType = StringComparison.CurrentCulture)
+#else
 		public static void EndsWith(ReadOnlyMemory<char> expectedEndMemory, ReadOnlyMemory<char> actualMemory, StringComparison comparisonType = StringComparison.CurrentCulture)
-			=> EndsWith(expectedEndMemory.Span, actualMemory.Span, comparisonType);
+#endif
+		{
+			GuardArgumentNotNull(nameof(expectedEndMemory), expectedEndMemory);
+#if XUNIT_NULLABLE
+			EndsWith(expectedEndMemory.ToString(), actualMemory?.ToString(), comparisonType);//use string comparison for it's strong output
+#else
+			EndsWith(expectedEndMemory.ToString(), actualMemory.ToString(), comparisonType);//use string comparison for it's strong output
+#endif
+		}
 
 		/// <summary>
 		/// Verifies that two Memory values are equivalent.
@@ -175,7 +303,11 @@ namespace Xunit
 		/// <param name="expectedMemory">The expected Memory value.</param>
 		/// <param name="actualMemory">The actual Memory value.</param>
 		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+#if XUNIT_NULLABLE
+		public static void Equal(Memory<char> expectedMemory, ReadOnlyMemory<char>? actualMemory)
+#else
 		public static void Equal(Memory<char> expectedMemory, ReadOnlyMemory<char> actualMemory)
+#endif
 			=> Equal(expectedMemory, actualMemory, false, false, false);
 
 		/// <summary>
@@ -184,7 +316,11 @@ namespace Xunit
 		/// <param name="expectedMemory">The expected Memory value.</param>
 		/// <param name="actualMemory">The actual Memory value.</param>
 		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+#if XUNIT_NULLABLE
+		public static void Equal(ReadOnlyMemory<char> expectedMemory, ReadOnlyMemory<char>? actualMemory)
+#else
 		public static void Equal(ReadOnlyMemory<char> expectedMemory, ReadOnlyMemory<char> actualMemory)
+#endif
 			=> Equal(expectedMemory, actualMemory, false, false, false);
 
 		/// <summary>
@@ -196,8 +332,12 @@ namespace Xunit
 		/// <param name="ignoreLineEndingDifferences">If set to <c>true</c>, treats \r\n, \r, and \n as equivalent.</param>
 		/// <param name="ignoreWhiteSpaceDifferences">If set to <c>true</c>, treats spaces and tabs (in any non-zero quantity) as equivalent.</param>
 		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+#if XUNIT_NULLABLE
+		public static void Equal(Memory<char> expectedMemory, ReadOnlyMemory<char>? actualMemory, bool ignoreCase = false, bool ignoreLineEndingDifferences = false, bool ignoreWhiteSpaceDifferences = false)
+#else
 		public static void Equal(Memory<char> expectedMemory, ReadOnlyMemory<char> actualMemory, bool ignoreCase = false, bool ignoreLineEndingDifferences = false, bool ignoreWhiteSpaceDifferences = false)
-			=> Equal(expectedMemory.Span, actualMemory.Span, ignoreCase, ignoreLineEndingDifferences, ignoreWhiteSpaceDifferences);
+#endif
+			=> EqualImp(expectedMemory, actualMemory, ignoreCase, ignoreLineEndingDifferences, ignoreWhiteSpaceDifferences);
 
 		/// <summary>
 		/// Verifies that two Memory values are equivalent.
@@ -208,8 +348,41 @@ namespace Xunit
 		/// <param name="ignoreLineEndingDifferences">If set to <c>true</c>, treats \r\n, \r, and \n as equivalent.</param>
 		/// <param name="ignoreWhiteSpaceDifferences">If set to <c>true</c>, treats spaces and tabs (in any non-zero quantity) as equivalent.</param>
 		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+#if XUNIT_NULLABLE
+		public static void Equal(ReadOnlyMemory<char> expectedMemory, ReadOnlyMemory<char>? actualMemory, bool ignoreCase = false, bool ignoreLineEndingDifferences = false, bool ignoreWhiteSpaceDifferences = false)
+#else
 		public static void Equal(ReadOnlyMemory<char> expectedMemory, ReadOnlyMemory<char> actualMemory, bool ignoreCase = false, bool ignoreLineEndingDifferences = false, bool ignoreWhiteSpaceDifferences = false)
-			=> Equal(expectedMemory.Span, actualMemory.Span, ignoreCase, ignoreLineEndingDifferences, ignoreWhiteSpaceDifferences);
+#endif
+			=> EqualImp(expectedMemory, actualMemory, ignoreCase, ignoreLineEndingDifferences, ignoreWhiteSpaceDifferences);
+
+		/// <summary>
+		/// Verifies that two Memory values are equivalent.
+		/// </summary>
+		/// <param name="expectedMemory">The expected Memory value.</param>
+		/// <param name="actualMemory">The actual Memory value.</param>
+		/// <param name="ignoreCase">If set to <c>true</c>, ignores cases differences. The invariant culture is used.</param>
+		/// <param name="ignoreLineEndingDifferences">If set to <c>true</c>, treats \r\n, \r, and \n as equivalent.</param>
+		/// <param name="ignoreWhiteSpaceDifferences">If set to <c>true</c>, treats spaces and tabs (in any non-zero quantity) as equivalent.</param>
+		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+#if XUNIT_NULLABLE
+		public static void Equal(Memory<char> expectedMemory, Memory<char>? actualMemory, bool ignoreCase = false, bool ignoreLineEndingDifferences = false, bool ignoreWhiteSpaceDifferences = false)
+#else
+		public static void Equal(Memory<char> expectedMemory, Memory<char> actualMemory, bool ignoreCase = false, bool ignoreLineEndingDifferences = false, bool ignoreWhiteSpaceDifferences = false)
+#endif
+			=> EqualImp(expectedMemory, actualMemory, ignoreCase, ignoreLineEndingDifferences, ignoreWhiteSpaceDifferences);
+
+#if XUNIT_NULLABLE
+		private static void EqualImp(ReadOnlyMemory<char> expectedMemory, ReadOnlyMemory<char>? actualMemory, bool ignoreCase = false, bool ignoreLineEndingDifferences = false, bool ignoreWhiteSpaceDifferences = false)
+#else
+		private static void EqualImp(ReadOnlyMemory<char> expectedMemory, ReadOnlyMemory<char> actualMemory, bool ignoreCase = false, bool ignoreLineEndingDifferences = false, bool ignoreWhiteSpaceDifferences = false)
+#endif
+		{
+#if XUNIT_NULLABLE
+			Equal(expectedMemory.ToString(), actualMemory?.ToString(), ignoreCase, ignoreLineEndingDifferences, ignoreWhiteSpaceDifferences);//use string comparison for it's strong output
+#else
+			Equal(expectedMemory.ToString(), actualMemory.ToString(), ignoreCase, ignoreLineEndingDifferences, ignoreWhiteSpaceDifferences);//use string comparison for it's strong output
+#endif
+		}
 
 		/// <summary>
 		/// Verifies that two Memory values are equivalent.
@@ -217,8 +390,12 @@ namespace Xunit
 		/// <param name="expectedMemory">The expected Memory value.</param>
 		/// <param name="actualMemory">The actual Memory value.</param>
 		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+#if XUNIT_NULLABLE
 		public static void Equal<T>(ReadOnlyMemory<T> expectedMemory, ReadOnlyMemory<T> actualMemory) where T : IEquatable<T>
-			=> Equal(expectedMemory.Span, actualMemory.Span);
+#else
+		public static void Equal<T>(ReadOnlyMemory<T> expectedMemory, ReadOnlyMemory<T> actualMemory) where T : IEquatable<T>
+#endif
+			=> EqualImp<T>(expectedMemory, actualMemory);
 
 		/// <summary>
 		/// Verifies that two Memory values are equivalent.
@@ -226,8 +403,12 @@ namespace Xunit
 		/// <param name="expectedMemory">The expected Memory value.</param>
 		/// <param name="actualMemory">The actual Memory value.</param>
 		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+#if XUNIT_NULLABLE
 		public static void Equal<T>(Memory<T> expectedMemory, ReadOnlyMemory<T> actualMemory) where T : IEquatable<T>
-			=> Equal(expectedMemory.Span, actualMemory.Span);
+#else
+		public static void Equal<T>(Memory<T> expectedMemory, ReadOnlyMemory<T> actualMemory) where T : IEquatable<T>
+#endif
+			=> EqualImp<T>(expectedMemory, actualMemory);
 
 		/// <summary>
 		/// Verifies that two Memory values are equivalent.
@@ -235,7 +416,17 @@ namespace Xunit
 		/// <param name="expectedMemory">The expected Memory value.</param>
 		/// <param name="actualMemory">The actual Memory value.</param>
 		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+#if XUNIT_NULLABLE
 		public static void Equal<T>(Memory<T> expectedMemory, Memory<T> actualMemory) where T : IEquatable<T>
-			=> Equal(expectedMemory.Span, actualMemory.Span);
+#else
+		public static void Equal<T>(Memory<T> expectedMemory, Memory<T> actualMemory) where T : IEquatable<T>
+#endif
+			=> EqualImp<T>(expectedMemory, actualMemory);
+
+		private static void EqualImp<T>(ReadOnlyMemory<T> expectedMemory, ReadOnlyMemory<T> actualMemory) where T : IEquatable<T>
+		{
+			GuardArgumentNotNull(nameof(expectedMemory), expectedMemory);
+			Equal(expectedMemory.Span.ToArray(), actualMemory.Span.ToArray(), GetEqualityComparer<T>());
+		}
 	}
 }

--- a/MemoryAsserts.cs
+++ b/MemoryAsserts.cs
@@ -1,0 +1,241 @@
+﻿using System;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+		//NOTE: MemoryAssert logic is dependent on Span asserts. The memory asserts that are not just redirects within the calss use the .span property of memory to perform assertions
+
+		//NOTE: there is an implicit conversion operator on Memory<T> to ReadOnlyMemory<T> I didn't create permutations of all the combinations 
+		//		of Memory and ReadOnlyMemory for each method, but I did create permutations for each argument as a hint to the compiler to help 
+		//		it select the right method.
+
+		//NOTE: we could consider StartsWith<T> and EndsWith<T> with both arguments as ReadOnlyMemory<T>, and use the Memory extension methods to check difference
+		//		BUT: the current Exceptions for startswith and endswith are only built for string types, so those would need a change (or new non-string versions created).
+
+		/// <summary>
+		/// Verifies that a Memory contains a given sub-Memory, using the default StringComparison.CurrentCulture comparison type.
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the sub-Memory is not present inside the Memory</exception>
+		public static void Contains(Memory<char> expectedSubMemory, ReadOnlyMemory<char> actualMemory)
+			=> Contains(expectedSubMemory, actualMemory, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a Memory contains a given sub-Memory, using the default StringComparison.CurrentCulture comparison type.
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the sub-Memory is not present inside the Memory</exception>
+		public static void Contains(ReadOnlyMemory<char> expectedSubMemory, ReadOnlyMemory<char> actualMemory)
+			=> Contains(expectedSubMemory, actualMemory, StringComparison.CurrentCulture);
+
+
+		/// <summary>
+		/// Verifies that a Memory contains a given sub-Memory, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="ContainsException">Thrown when the sub-Memory is not present inside the Memory</exception>
+		public static void Contains(ReadOnlyMemory<char> expectedSubMemory, ReadOnlyMemory<char> actualMemory, StringComparison comparisonType = StringComparison.CurrentCulture)
+			=> Contains(expectedSubMemory.Span, actualMemory.Span, comparisonType);
+
+		/// <summary>
+		/// Verifies that a Memory contains a given sub-Memory
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the sub-Memory is not present inside the Memory</exception>
+		public static void Contains<T>(Memory<T> expectedSubMemory, ReadOnlyMemory<T> actualMemory) where T : IEquatable<T>
+			=> Contains(expectedSubMemory.Span, actualMemory.Span);
+
+		/// <summary>
+		/// Verifies that a Memory contains a given sub-Memory
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the sub-Memory is not present inside the Memory</exception>
+		public static void Contains<T>(ReadOnlyMemory<T> expectedSubMemory, ReadOnlyMemory<T> actualMemory) where T : IEquatable<T>
+			=> Contains(expectedSubMemory.Span, actualMemory.Span);
+
+		/// <summary>
+		/// Verifies that a Memory does not contain a given sub-Memory, using the default StringComparison.CurrentCulture comparison type.
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected not to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-Memory is present inside the Memory</exception>
+		public static void DoesNotContain(Memory<char> expectedSubMemory, ReadOnlyMemory<char> actualMemory)
+			=> DoesNotContain(expectedSubMemory, actualMemory, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a Memory does not contain a given sub-Memory, using the default StringComparison.CurrentCulture comparison type.
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected not to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-Memory is present inside the Memory</exception>
+		public static void DoesNotContain(ReadOnlyMemory<char> expectedSubMemory, ReadOnlyMemory<char> actualMemory)
+			=> DoesNotContain(expectedSubMemory, actualMemory, StringComparison.CurrentCulture);
+
+
+		/// <summary>
+		/// Verifies that a Memory does not contain a given sub-Memory, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected not to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-Memory is present inside the Memory</exception>
+		public static void DoesNotContain(ReadOnlyMemory<char> expectedSubMemory, ReadOnlyMemory<char> actualMemory, StringComparison comparisonType = StringComparison.CurrentCulture)
+			=> DoesNotContain(expectedSubMemory.Span, actualMemory.Span, comparisonType);
+
+		/// <summary>
+		/// Verifies that a Memory does not contain a given sub-Memory
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected not to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-Memory is present inside the Memory</exception>
+		public static void DoesNotContain<T>(ReadOnlyMemory<T> expectedSubMemory, ReadOnlyMemory<T> actualMemory) where T : IEquatable<T>
+			=> DoesNotContain(expectedSubMemory.Span, actualMemory.Span);
+
+		/// <summary>
+		/// Verifies that a Memory does not contain a given sub-Memory
+		/// </summary>
+		/// <param name="expectedSubMemory">The sub-Memory expected not to be in the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-Memory is present inside the Memory</exception>
+		public static void DoesNotContain<T>(Memory<T> expectedSubMemory, ReadOnlyMemory<T> actualMemory) where T : IEquatable<T>
+			=> DoesNotContain(expectedSubMemory.Span, actualMemory.Span);
+
+		/// <summary>
+		/// Verifies that a Memory starts with a given sub-Memory, using the default StringComparison.CurrentCulture comparison type.
+		/// </summary>
+		/// <param name="expectedStartMemory">The sub-Memory expected to be at the start of the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="StartsWithException">Thrown when the Memory does not start with the expected subMemory</exception>
+		public static void StartsWith(Memory<char> expectedStartMemory, ReadOnlyMemory<char> actualMemory)
+			=> StartsWith(expectedStartMemory, actualMemory, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a Memory starts with a given sub-Memory, using the default StringComparison.CurrentCulture comparison type.
+		/// </summary>
+		/// <param name="expectedStartMemory">The sub-Memory expected to be at the start of the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="StartsWithException">Thrown when the Memory does not start with the expected subMemory</exception>
+		public static void StartsWith(ReadOnlyMemory<char> expectedStartMemory, ReadOnlyMemory<char> actualMemory)
+			=> StartsWith(expectedStartMemory, actualMemory, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a Memory starts with a given sub-Memory, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedStartMemory">The sub-Memory expected to be at the start of the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="StartsWithException">Thrown when the Memory does not start with the expected subMemory</exception>
+		public static void StartsWith(ReadOnlyMemory<char> expectedStartMemory, ReadOnlyMemory<char> actualMemory, StringComparison comparisonType = StringComparison.CurrentCulture)
+			=> StartsWith(expectedStartMemory.Span, actualMemory.Span, comparisonType);
+
+		/// <summary>
+		/// Verifies that a Memory ends with a given sub-Memory, using the default StringComparison.CurrentCulture comparison type.
+		/// </summary>
+		/// <param name="expectedEndMemory">The sub-Memory expected to be at the end of the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="EndsWithException">Thrown when the Memory does not end with the expected subMemory</exception>
+		public static void EndsWith(Memory<char> expectedEndMemory, ReadOnlyMemory<char> actualMemory)
+			=> EndsWith(expectedEndMemory, actualMemory, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a Memory ends with a given sub-Memory, using the default StringComparison.CurrentCulture comparison type.
+		/// </summary>
+		/// <param name="expectedEndMemory">The sub-Memory expected to be at the end of the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <exception cref="EndsWithException">Thrown when the Memory does not end with the expected subMemory</exception>
+		public static void EndsWith(ReadOnlyMemory<char> expectedEndMemory, ReadOnlyMemory<char> actualMemory)
+			=> EndsWith(expectedEndMemory, actualMemory, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a Memory ends with a given sub-Memory, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedEndMemory">The sub-Memory expected to be at the end of the Memory</param>
+		/// <param name="actualMemory">The Memory to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="EndsWithException">Thrown when the Memory does not end with the expected subMemory</exception>
+		public static void EndsWith(ReadOnlyMemory<char> expectedEndMemory, ReadOnlyMemory<char> actualMemory, StringComparison comparisonType = StringComparison.CurrentCulture)
+			=> EndsWith(expectedEndMemory.Span, actualMemory.Span, comparisonType);
+
+		/// <summary>
+		/// Verifies that two Memory values are equivalent.
+		/// </summary>
+		/// <param name="expectedMemory">The expected Memory value.</param>
+		/// <param name="actualMemory">The actual Memory value.</param>
+		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+		public static void Equal(Memory<char> expectedMemory, ReadOnlyMemory<char> actualMemory)
+			=> Equal(expectedMemory, actualMemory, false, false, false);
+
+		/// <summary>
+		/// Verifies that two Memory values are equivalent.
+		/// </summary>
+		/// <param name="expectedMemory">The expected Memory value.</param>
+		/// <param name="actualMemory">The actual Memory value.</param>
+		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+		public static void Equal(ReadOnlyMemory<char> expectedMemory, ReadOnlyMemory<char> actualMemory)
+			=> Equal(expectedMemory, actualMemory, false, false, false);
+
+		/// <summary>
+		/// Verifies that two Memory values are equivalent.
+		/// </summary>
+		/// <param name="expectedMemory">The expected Memory value.</param>
+		/// <param name="actualMemory">The actual Memory value.</param>
+		/// <param name="ignoreCase">If set to <c>true</c>, ignores cases differences. The invariant culture is used.</param>
+		/// <param name="ignoreLineEndingDifferences">If set to <c>true</c>, treats \r\n, \r, and \n as equivalent.</param>
+		/// <param name="ignoreWhiteSpaceDifferences">If set to <c>true</c>, treats spaces and tabs (in any non-zero quantity) as equivalent.</param>
+		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+		public static void Equal(Memory<char> expectedMemory, ReadOnlyMemory<char> actualMemory, bool ignoreCase = false, bool ignoreLineEndingDifferences = false, bool ignoreWhiteSpaceDifferences = false)
+			=> Equal(expectedMemory.Span, actualMemory.Span, ignoreCase, ignoreLineEndingDifferences, ignoreWhiteSpaceDifferences);
+
+		/// <summary>
+		/// Verifies that two Memory values are equivalent.
+		/// </summary>
+		/// <param name="expectedMemory">The expected Memory value.</param>
+		/// <param name="actualMemory">The actual Memory value.</param>
+		/// <param name="ignoreCase">If set to <c>true</c>, ignores cases differences. The invariant culture is used.</param>
+		/// <param name="ignoreLineEndingDifferences">If set to <c>true</c>, treats \r\n, \r, and \n as equivalent.</param>
+		/// <param name="ignoreWhiteSpaceDifferences">If set to <c>true</c>, treats spaces and tabs (in any non-zero quantity) as equivalent.</param>
+		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+		public static void Equal(ReadOnlyMemory<char> expectedMemory, ReadOnlyMemory<char> actualMemory, bool ignoreCase = false, bool ignoreLineEndingDifferences = false, bool ignoreWhiteSpaceDifferences = false)
+			=> Equal(expectedMemory.Span, actualMemory.Span, ignoreCase, ignoreLineEndingDifferences, ignoreWhiteSpaceDifferences);
+
+		/// <summary>
+		/// Verifies that two Memory values are equivalent.
+		/// </summary>
+		/// <param name="expectedMemory">The expected Memory value.</param>
+		/// <param name="actualMemory">The actual Memory value.</param>
+		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+		public static void Equal<T>(ReadOnlyMemory<T> expectedMemory, ReadOnlyMemory<T> actualMemory) where T : IEquatable<T>
+			=> Equal(expectedMemory.Span, actualMemory.Span);
+
+		/// <summary>
+		/// Verifies that two Memory values are equivalent.
+		/// </summary>
+		/// <param name="expectedMemory">The expected Memory value.</param>
+		/// <param name="actualMemory">The actual Memory value.</param>
+		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+		public static void Equal<T>(Memory<T> expectedMemory, ReadOnlyMemory<T> actualMemory) where T : IEquatable<T>
+			=> Equal(expectedMemory.Span, actualMemory.Span);
+
+		/// <summary>
+		/// Verifies that two Memory values are equivalent.
+		/// </summary>
+		/// <param name="expectedMemory">The expected Memory value.</param>
+		/// <param name="actualMemory">The actual Memory value.</param>
+		/// <exception cref="EqualException">Thrown when the Memory values are not equivalent.</exception>
+		public static void Equal<T>(Memory<T> expectedMemory, Memory<T> actualMemory) where T : IEquatable<T>
+			=> Equal(expectedMemory.Span, actualMemory.Span);
+	}
+}

--- a/Sdk/Exceptions/ContainsException.cs
+++ b/Sdk/Exceptions/ContainsException.cs
@@ -36,7 +36,5 @@ namespace Xunit.Sdk
 		/// <param name="actual">The actual value</param>
 		public static ContainsException Create<T>(ReadOnlySpan<T> expected, ReadOnlySpan<T> actual) =>
 			RefStructExceptionHelper.CreateException(expected, actual, (e, a) => new ContainsException(e, a));
-
-
 	}
 }

--- a/Sdk/Exceptions/ContainsException.cs
+++ b/Sdk/Exceptions/ContainsException.cs
@@ -2,6 +2,8 @@
 #nullable enable
 #endif
 
+using System;
+
 namespace Xunit.Sdk
 {
 	/// <summary>
@@ -26,5 +28,15 @@ namespace Xunit.Sdk
 #endif
 			: base(expected, actual, "Assert.Contains() Failure", "Not found", "In value")
 		{ }
+
+		/// <summary>
+		/// Creates a new instance of the <see cref="ContainsException"/> class.
+		/// </summary>
+		/// <param name="expected">The expected object value</param>
+		/// <param name="actual">The actual value</param>
+		public static ContainsException Create<T>(ReadOnlySpan<T> expected, ReadOnlySpan<T> actual) =>
+			RefStructExceptionHelper.CreateException(expected, actual, (e, a) => new ContainsException(e, a));
+
+
 	}
 }

--- a/Sdk/Exceptions/DoesNotContainException.cs
+++ b/Sdk/Exceptions/DoesNotContainException.cs
@@ -37,6 +37,5 @@ namespace Xunit.Sdk
 		/// <returns></returns>
 		public static DoesNotContainException Create<T>(ReadOnlySpan<T> expected, ReadOnlySpan<T> actual) =>
 			RefStructExceptionHelper.CreateException(expected, actual, (e, a) => new DoesNotContainException(e, a));
-
 	}
 }

--- a/Sdk/Exceptions/DoesNotContainException.cs
+++ b/Sdk/Exceptions/DoesNotContainException.cs
@@ -1,6 +1,7 @@
 #if XUNIT_NULLABLE
 #nullable enable
 #endif
+using System;
 
 namespace Xunit.Sdk
 {
@@ -26,5 +27,16 @@ namespace Xunit.Sdk
 #endif
 			: base(expected, actual, "Assert.DoesNotContain() Failure", "Found", "In value")
 		{ }
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="expected">The expected object value</param>
+		/// <param name="actual">The actual value</param>
+		/// <returns></returns>
+		public static DoesNotContainException Create<T>(ReadOnlySpan<T> expected, ReadOnlySpan<T> actual) =>
+			RefStructExceptionHelper.CreateException(expected, actual, (e, a) => new DoesNotContainException(e, a));
+
 	}
 }

--- a/Sdk/Exceptions/RefStructExceptionHelper.cs
+++ b/Sdk/Exceptions/RefStructExceptionHelper.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Class containing helper methods for creating ref struct specific exceptions (e.g. Span or ReadOnlySpan types)
+	/// As these ref struct types do not support boxing to object, and thus cannot use the common constructors
+	/// </summary>
+	public static class RefStructExceptionHelper
+	{
+		/// <summary>
+		/// used to invoke constructors that need 2 parameters of type object. Object is not boxable by ReadOnlySpan.
+		/// This method simply converts the ReadOnlySpans to arrays of the native type, and then invokes the function (presumably a constructor)
+		/// </summary>
+		/// <typeparam name="T">The Type of object to return (generally the exception type</typeparam>
+		/// <typeparam name="U">The type contained within the ReadOnlySpan (or Span due to implicit conversation operator)</typeparam>
+		/// <param name="expected">The Expected Value</param>
+		/// <param name="actual">The acutal Value</param>
+		/// <param name="func">the function to invoke, this function generally will be a constructor</param>
+		/// <returns></returns>
+		public static T CreateException<T, U>(ReadOnlySpan<U> expected, ReadOnlySpan<U> actual, Func<object, object, T> func)
+			=> func.Invoke(expected.ToArray(), actual.ToArray());
+	}
+}

--- a/SpanAsserts.cs
+++ b/SpanAsserts.cs
@@ -1,0 +1,257 @@
+﻿using System;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+
+		//NOTE: we could consider StartsWith<T> and EndsWith<T> and use the Span extension methods to check difference, but, the current 
+		//		Exceptions for startswith and endswith are only built for string types, so those would need a change (or new non-string versions created).
+
+		//NOTE: ref struct types (Span, ReadOnlySpan) are not Nullable, and thus there is no XUNIT_NULLABLE usage currently in this class
+		//		This also means that null spans are identical to empty spans, (both in essence point to an empty array of whatever type)
+
+		//NOTE: all MemoryAsserts are dependent on Span asserts. The memory asserts use the .span property of memory to perform assertions
+
+		//NOTE: there is an implicit conversion operator on Span<T> to ReadOnlySpan<T> I didn't create permutations of all the combinations 
+		//		of Span and ReadOnlySpan for each method, but I did create permutations for each first argument as a hint to the compiler to help 
+		//		it select the right method. Without these null arguments can cause compiler errors
+
+		/// <summary>
+		/// Verifies that a span contains a given sub-span, using the default StringComparison.CurrentCulture comparison type.
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the sub-span is not present inside the span</exception>
+		public static void Contains(Span<char> expectedSubSpan, ReadOnlySpan<char> actualSpan)
+			=> Contains(expectedSubSpan, actualSpan, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a span contains a given sub-span, using the default StringComparison.CurrentCulture comparison type.
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the sub-span is not present inside the span</exception>
+		public static void Contains(ReadOnlySpan<char> expectedSubSpan, ReadOnlySpan<char> actualSpan)
+			=> Contains(expectedSubSpan, actualSpan, StringComparison.CurrentCulture);
+
+
+		/// <summary>
+		/// Verifies that a span contains a given sub-span, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="ContainsException">Thrown when the sub-span is not present inside the span</exception>
+		public static void Contains(ReadOnlySpan<char> expectedSubSpan, ReadOnlySpan<char> actualSpan, StringComparison comparisonType = StringComparison.CurrentCulture)
+			=> Contains(expectedSubSpan.ToString(), actualSpan.ToString(), comparisonType);
+
+		/// <summary>
+		/// Verifies that a span contains a given sub-span
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the sub-span is not present inside the span</exception>
+		public static void Contains<T>(Span<T> expectedSubSpan, ReadOnlySpan<T> actualSpan) where T : IEquatable<T>
+		{
+			if (actualSpan == null || actualSpan.IndexOf(expectedSubSpan) < 0)
+				throw ContainsException.Create(expectedSubSpan, actualSpan);
+		}
+
+		/// <summary>
+		/// Verifies that a span contains a given sub-span
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the sub-span is not present inside the span</exception>
+		public static void Contains<T>(ReadOnlySpan<T> expectedSubSpan, ReadOnlySpan<T> actualSpan) where T : IEquatable<T>
+		{
+			if (actualSpan == null || actualSpan.IndexOf(expectedSubSpan) < 0)
+				throw ContainsException.Create(expectedSubSpan, actualSpan);
+		}
+
+		/// <summary>
+		/// Verifies that a span does not contain a given sub-span, using the default StringComparison.CurrentCulture comparison type.
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected not to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-span is present inside the span</exception>
+		public static void DoesNotContain(Span<char> expectedSubSpan, ReadOnlySpan<char> actualSpan)
+			=> DoesNotContain(expectedSubSpan, actualSpan, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a span does not contain a given sub-span, using the default StringComparison.CurrentCulture comparison type.
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected not to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-span is present inside the span</exception>
+		public static void DoesNotContain(ReadOnlySpan<char> expectedSubSpan, ReadOnlySpan<char> actualSpan)
+			=> DoesNotContain(expectedSubSpan, actualSpan, StringComparison.CurrentCulture);
+
+
+		/// <summary>
+		/// Verifies that a span does not contain a given sub-span, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected not to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-span is present inside the span</exception>
+		public static void DoesNotContain(ReadOnlySpan<char> expectedSubSpan, ReadOnlySpan<char> actualSpan, StringComparison comparisonType = StringComparison.CurrentCulture)
+			=> DoesNotContain(expectedSubSpan.ToString(), actualSpan.ToString(), comparisonType);
+
+		/// <summary>
+		/// Verifies that a span does not contain a given sub-span
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected not to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-span is present inside the span</exception>
+		public static void DoesNotContain<T>(ReadOnlySpan<T> expectedSubSpan, ReadOnlySpan<T> actualSpan) where T : IEquatable<T>
+		{
+			if (actualSpan != null && actualSpan.IndexOf(expectedSubSpan) >= 0)
+				throw DoesNotContainException.Create(expectedSubSpan, actualSpan);
+		}
+
+		/// <summary>
+		/// Verifies that a span does not contain a given sub-span
+		/// </summary>
+		/// <param name="expectedSubSpan">The sub-span expected not to be in the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the sub-span is present inside the span</exception>
+		public static void DoesNotContain<T>(Span<T> expectedSubSpan, ReadOnlySpan<T> actualSpan) where T : IEquatable<T>
+		{
+			if (actualSpan != null && actualSpan.IndexOf(expectedSubSpan) >= 0)
+				throw DoesNotContainException.Create(expectedSubSpan, actualSpan);
+		}
+
+		/// <summary>
+		/// Verifies that a span starts with a given sub-span, using the default StringComparison.CurrentCulture comparison type.
+		/// </summary>
+		/// <param name="expectedStartSpan">The sub-span expected to be at the start of the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="StartsWithException">Thrown when the span does not start with the expected subspan</exception>
+		public static void StartsWith(Span<char> expectedStartSpan, ReadOnlySpan<char> actualSpan)
+			=> StartsWith(expectedStartSpan, actualSpan, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a span starts with a given sub-span, using the default StringComparison.CurrentCulture comparison type.
+		/// </summary>
+		/// <param name="expectedStartSpan">The sub-span expected to be at the start of the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="StartsWithException">Thrown when the span does not start with the expected subspan</exception>
+		public static void StartsWith(ReadOnlySpan<char> expectedStartSpan, ReadOnlySpan<char> actualSpan)
+			=> StartsWith(expectedStartSpan, actualSpan, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a span starts with a given sub-span, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedStartSpan">The sub-span expected to be at the start of the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="StartsWithException">Thrown when the span does not start with the expected subspan</exception>
+		public static void StartsWith(ReadOnlySpan<char> expectedStartSpan, ReadOnlySpan<char> actualSpan, StringComparison comparisonType = StringComparison.CurrentCulture)
+			=> StartsWith(expectedStartSpan.ToString(), actualSpan.ToString(), comparisonType);
+
+		/// <summary>
+		/// Verifies that a span ends with a given sub-span, using the default StringComparison.CurrentCulture comparison type.
+		/// </summary>
+		/// <param name="expectedEndSpan">The sub-span expected to be at the end of the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="EndsWithException">Thrown when the span does not end with the expected subspan</exception>
+		public static void EndsWith(Span<char> expectedEndSpan, ReadOnlySpan<char> actualSpan)
+			=> EndsWith(expectedEndSpan, actualSpan, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a span ends with a given sub-span, using the default StringComparison.CurrentCulture comparison type.
+		/// </summary>
+		/// <param name="expectedEndSpan">The sub-span expected to be at the end of the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <exception cref="EndsWithException">Thrown when the span does not end with the expected subspan</exception>
+		public static void EndsWith(ReadOnlySpan<char> expectedEndSpan, ReadOnlySpan<char> actualSpan)
+			=> EndsWith(expectedEndSpan, actualSpan, StringComparison.CurrentCulture);
+
+		/// <summary>
+		/// Verifies that a span ends with a given sub-span, using the given comparison type.
+		/// </summary>
+		/// <param name="expectedEndSpan">The sub-span expected to be at the end of the span</param>
+		/// <param name="actualSpan">The span to be inspected</param>
+		/// <param name="comparisonType">The type of string comparison to perform</param>
+		/// <exception cref="EndsWithException">Thrown when the span does not end with the expected subspan</exception>
+		public static void EndsWith(ReadOnlySpan<char> expectedEndSpan, ReadOnlySpan<char> actualSpan, StringComparison comparisonType = StringComparison.CurrentCulture)
+			=> EndsWith(expectedEndSpan.ToString(), actualSpan.ToString(), comparisonType);
+
+		/// <summary>
+		/// Verifies that two spans are equivalent.
+		/// </summary>
+		/// <param name="expectedSpan">The expected span value.</param>
+		/// <param name="actualSpan">The actual span value.</param>
+		/// <exception cref="EqualException">Thrown when the spans are not equivalent.</exception>
+		public static void Equal(Span<char> expectedSpan, ReadOnlySpan<char> actualSpan)
+			=> Equal(expectedSpan, actualSpan, false, false, false);
+
+		/// <summary>
+		/// Verifies that two spans are equivalent.
+		/// </summary>
+		/// <param name="expectedSpan">The expected span value.</param>
+		/// <param name="actualSpan">The actual span value.</param>
+		/// <exception cref="EqualException">Thrown when the spans are not equivalent.</exception>
+		public static void Equal(ReadOnlySpan<char> expectedSpan, ReadOnlySpan<char> actualSpan)
+			=> Equal(expectedSpan, actualSpan, false, false, false);
+
+		/// <summary>
+		/// Verifies that two spans are equivalent.
+		/// </summary>
+		/// <param name="expectedSpan">The expected span value.</param>
+		/// <param name="actualSpan">The actual span value.</param>
+		/// <param name="ignoreCase">If set to <c>true</c>, ignores cases differences. The invariant culture is used.</param>
+		/// <param name="ignoreLineEndingDifferences">If set to <c>true</c>, treats \r\n, \r, and \n as equivalent.</param>
+		/// <param name="ignoreWhiteSpaceDifferences">If set to <c>true</c>, treats spaces and tabs (in any non-zero quantity) as equivalent.</param>
+		/// <exception cref="EqualException">Thrown when the spans are not equivalent.</exception>
+		public static void Equal(Span<char> expectedSpan, ReadOnlySpan<char> actualSpan, bool ignoreCase = false, bool ignoreLineEndingDifferences = false, bool ignoreWhiteSpaceDifferences = false)
+			=> Equal(expectedSpan.ToString(), actualSpan.ToString(), ignoreCase, ignoreLineEndingDifferences, ignoreWhiteSpaceDifferences);
+
+		/// <summary>
+		/// Verifies that two spans are equivalent.
+		/// </summary>
+		/// <param name="expectedSpan">The expected span value.</param>
+		/// <param name="actualSpan">The actual span value.</param>
+		/// <param name="ignoreCase">If set to <c>true</c>, ignores cases differences. The invariant culture is used.</param>
+		/// <param name="ignoreLineEndingDifferences">If set to <c>true</c>, treats \r\n, \r, and \n as equivalent.</param>
+		/// <param name="ignoreWhiteSpaceDifferences">If set to <c>true</c>, treats spaces and tabs (in any non-zero quantity) as equivalent.</param>
+		/// <exception cref="EqualException">Thrown when the spans are not equivalent.</exception>
+		public static void Equal(ReadOnlySpan<char> expectedSpan, ReadOnlySpan<char> actualSpan, bool ignoreCase = false, bool ignoreLineEndingDifferences = false, bool ignoreWhiteSpaceDifferences = false)
+			=> Equal(expectedSpan.ToString(), actualSpan.ToString(), ignoreCase, ignoreLineEndingDifferences, ignoreWhiteSpaceDifferences);
+
+		/// <summary>
+		/// Verifies that two spans are equivalent.
+		/// </summary>
+		/// <param name="expectedSpan">The expected span value.</param>
+		/// <param name="actualSpan">The actual span value.</param>
+		/// <exception cref="EqualException">Thrown when the spans are not equivalent.</exception>
+		public static void Equal<T>(ReadOnlySpan<T> expectedSpan, ReadOnlySpan<T> actualSpan) where T : IEquatable<T>
+			=> Equal(expectedSpan.ToArray(), actualSpan.ToArray(), GetEqualityComparer<T>());
+
+		/// <summary>
+		/// Verifies that two spans are equivalent.
+		/// </summary>
+		/// <param name="expectedSpan">The expected span value.</param>
+		/// <param name="actualSpan">The actual span value.</param>
+		/// <exception cref="EqualException">Thrown when the spans are not equivalent.</exception>
+		public static void Equal<T>(Span<T> expectedSpan, ReadOnlySpan<T> actualSpan) where T : IEquatable<T>
+			=> Equal(expectedSpan.ToArray(), actualSpan.ToArray(), GetEqualityComparer<T>());
+
+		/// <summary>
+		/// Verifies that two spans are equivalent.
+		/// </summary>
+		/// <param name="expectedSpan">The expected span value.</param>
+		/// <param name="actualSpan">The actual span value.</param>
+		/// <exception cref="EqualException">Thrown when the spans are not equivalent.</exception>
+		public static void Equal<T>(Span<T> expectedSpan, Span<T> actualSpan) where T : IEquatable<T>
+			=> Equal(expectedSpan.ToArray(), actualSpan.ToArray(), GetEqualityComparer<T>());
+	}
+}

--- a/SpanAsserts.cs
+++ b/SpanAsserts.cs
@@ -10,18 +10,15 @@ namespace Xunit
 #endif
 	partial class Assert
 	{
+		//NOTE: ref struct types (Span, ReadOnlySpan) are not Nullable, and thus there is no XUNIT_NULLABLE usage currently in this class
+		//		This also means that null spans are identical to empty spans, (both in essence point to a 0 sized array of whatever type)
 
 		//NOTE: we could consider StartsWith<T> and EndsWith<T> and use the Span extension methods to check difference, but, the current 
 		//		Exceptions for startswith and endswith are only built for string types, so those would need a change (or new non-string versions created).
 
-		//NOTE: ref struct types (Span, ReadOnlySpan) are not Nullable, and thus there is no XUNIT_NULLABLE usage currently in this class
-		//		This also means that null spans are identical to empty spans, (both in essence point to an empty array of whatever type)
-
-		//NOTE: all MemoryAsserts are dependent on Span asserts. The memory asserts use the .span property of memory to perform assertions
-
-		//NOTE: there is an implicit conversion operator on Span<T> to ReadOnlySpan<T> I didn't create permutations of all the combinations 
-		//		of Span and ReadOnlySpan for each method, but I did create permutations for each first argument as a hint to the compiler to help 
-		//		it select the right method. Without these null arguments can cause compiler errors
+		//NOTE: there is an implicit conversion operator on Span<T> to ReadOnlySpan<T> - however, I have found that the compiler sometimes struggles
+		//		with identifying the proper methods to use, thus I have overloaded quite a few of the assertions in terms of supplying both
+		//		Span and ReadOnlySpan based methods
 
 		/// <summary>
 		/// Verifies that a span contains a given sub-span, using the default StringComparison.CurrentCulture comparison type.
@@ -252,6 +249,15 @@ namespace Xunit
 		/// <param name="actualSpan">The actual span value.</param>
 		/// <exception cref="EqualException">Thrown when the spans are not equivalent.</exception>
 		public static void Equal<T>(Span<T> expectedSpan, Span<T> actualSpan) where T : IEquatable<T>
+			=> Equal(expectedSpan.ToArray(), actualSpan.ToArray(), GetEqualityComparer<T>());
+
+		/// <summary>
+		/// Verifies that two spans are equivalent.
+		/// </summary>
+		/// <param name="expectedSpan">The expected span value.</param>
+		/// <param name="actualSpan">The actual span value.</param>
+		/// <exception cref="EqualException">Thrown when the spans are not equivalent.</exception>
+		public static void Equal<T>(ReadOnlySpan<T> expectedSpan, Span<T> actualSpan) where T : IEquatable<T>
 			=> Equal(expectedSpan.ToArray(), actualSpan.ToArray(), GetEqualityComparer<T>());
 	}
 }


### PR DESCRIPTION
Fix 1966
Adds support for many typical assertions for both the (ReadOnly)Span and (ReadOnly)Memory types.
This includes support for the most common scenario where those types encapsulate char; behavior in these char scenarios aligns with typical string comparisons to give strong comparison and error support. Non-Char encapsulating types will behave very much like arrays of the native objects in terms of results.
Note: I just realized that this Issue was not identified as help wanted. No worries if it is rejected for that reason. This was a great learning experience for me in dealing with the innards of ref struct types.