### PR TITLE
Fix nullable cast

### DIFF
--- a/Sdk/AssertEqualityComparerAdapter.cs
+++ b/Sdk/AssertEqualityComparerAdapter.cs
@@ -31,12 +31,15 @@ namespace Xunit.Sdk
 		/// <inheritdoc/>
 #if XUNIT_NULLABLE
 		public new bool Equals(object? x, object? y)
+		{
+			return innerComparer.Equals((T?)x, (T?)y);
+		}
 #else
 		public new bool Equals(object x, object y)
-#endif
-		{
+		{	
 			return innerComparer.Equals((T)x, (T)y);
 		}
+#endif
 
 		/// <inheritdoc/>
 		public int GetHashCode(object obj)

--- a/Sdk/AssertEqualityComparerAdapter.cs
+++ b/Sdk/AssertEqualityComparerAdapter.cs
@@ -36,7 +36,7 @@ namespace Xunit.Sdk
 		}
 #else
 		public new bool Equals(object x, object y)
-		{	
+		{
 			return innerComparer.Equals((T)x, (T)y);
 		}
 #endif


### PR DESCRIPTION
In a future version of the compiler, this cast is a warning (csc version 3.10, change introduce [here](https://github.com/dotnet/roslyn/pull/48803))

This resolves the warning for this case.