### PR TITLE
Attribute collection equality assertions as allowing null

### DIFF
--- a/CollectionAsserts.cs
+++ b/CollectionAsserts.cs
@@ -8,10 +8,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Xunit.Sdk;
 
-#if XUNIT_NULLABLE
-using System.Diagnostics.CodeAnalysis;
-#endif
-
 #if XUNIT_VALUETASK
 using System.Threading.Tasks;
 #endif
@@ -508,8 +504,8 @@ namespace Xunit
 		/// <exception cref="EqualException">Thrown when the objects are not equal</exception>
 		public static void Equal<T>(
 #if XUNIT_NULLABLE
-			[AllowNull] IEnumerable<T> expected,
-			[AllowNull] IEnumerable<T> actual) =>
+			IEnumerable<T>? expected,
+			IEnumerable<T>? actual) =>
 #else
 			IEnumerable<T> expected,
 			IEnumerable<T> actual) =>
@@ -526,8 +522,8 @@ namespace Xunit
 		/// <exception cref="EqualException">Thrown when the objects are not equal</exception>
 		public static void Equal<T>(
 #if XUNIT_NULLABLE
-			[AllowNull] IEnumerable<T> expected,
-			[AllowNull] IEnumerable<T> actual,
+			IEnumerable<T>? expected,
+			IEnumerable<T>? actual,
 #else
 			IEnumerable<T> expected,
 			IEnumerable<T> actual,
@@ -566,8 +562,8 @@ namespace Xunit
 		/// <exception cref="NotEqualException">Thrown when the objects are equal</exception>
 		public static void NotEqual<T>(
 #if XUNIT_NULLABLE
-			[AllowNull] IEnumerable<T> expected,
-			[AllowNull] IEnumerable<T> actual) =>
+			IEnumerable<T>? expected,
+			IEnumerable<T>? actual) =>
 #else
 			IEnumerable<T> expected,
 			IEnumerable<T> actual) =>
@@ -584,8 +580,8 @@ namespace Xunit
 		/// <exception cref="NotEqualException">Thrown when the objects are equal</exception>
 		public static void NotEqual<T>(
 #if XUNIT_NULLABLE
-			[AllowNull] IEnumerable<T> expected,
-			[AllowNull] IEnumerable<T> actual,
+			IEnumerable<T>? expected,
+			IEnumerable<T>? actual,
 #else
 			IEnumerable<T> expected,
 			IEnumerable<T> actual,

--- a/CollectionAsserts.cs
+++ b/CollectionAsserts.cs
@@ -8,6 +8,10 @@ using System.Collections.Generic;
 using System.Linq;
 using Xunit.Sdk;
 
+#if XUNIT_NULLABLE
+using System.Diagnostics.CodeAnalysis;
+#endif
+
 #if XUNIT_VALUETASK
 using System.Threading.Tasks;
 #endif
@@ -503,8 +507,13 @@ namespace Xunit
 		/// <param name="actual">The value to be compared against</param>
 		/// <exception cref="EqualException">Thrown when the objects are not equal</exception>
 		public static void Equal<T>(
+#if XUNIT_NULLABLE
+			[AllowNull] IEnumerable<T> expected,
+			[AllowNull] IEnumerable<T> actual) =>
+#else
 			IEnumerable<T> expected,
 			IEnumerable<T> actual) =>
+#endif
 				Equal(expected, actual, GetEqualityComparer<IEnumerable<T>>());
 
 		/// <summary>
@@ -516,8 +525,13 @@ namespace Xunit
 		/// <param name="comparer">The comparer used to compare the two objects</param>
 		/// <exception cref="EqualException">Thrown when the objects are not equal</exception>
 		public static void Equal<T>(
+#if XUNIT_NULLABLE
+			[AllowNull] IEnumerable<T> expected,
+			[AllowNull] IEnumerable<T> actual,
+#else
 			IEnumerable<T> expected,
 			IEnumerable<T> actual,
+#endif
 			IEqualityComparer<T> comparer) =>
 				Equal(expected, actual, GetEqualityComparer<IEnumerable<T>>(new AssertEqualityComparerAdapter<T>(comparer)));
 
@@ -551,8 +565,13 @@ namespace Xunit
 		/// <param name="actual">The actual object</param>
 		/// <exception cref="NotEqualException">Thrown when the objects are equal</exception>
 		public static void NotEqual<T>(
+#if XUNIT_NULLABLE
+			[AllowNull] IEnumerable<T> expected,
+			[AllowNull] IEnumerable<T> actual) =>
+#else
 			IEnumerable<T> expected,
 			IEnumerable<T> actual) =>
+#endif
 				NotEqual(expected, actual, GetEqualityComparer<IEnumerable<T>>());
 
 		/// <summary>
@@ -564,8 +583,13 @@ namespace Xunit
 		/// <param name="comparer">The comparer used to compare the two objects</param>
 		/// <exception cref="NotEqualException">Thrown when the objects are equal</exception>
 		public static void NotEqual<T>(
+#if XUNIT_NULLABLE
+			[AllowNull] IEnumerable<T> expected,
+			[AllowNull] IEnumerable<T> actual,
+#else
 			IEnumerable<T> expected,
 			IEnumerable<T> actual,
+#endif
 			IEqualityComparer<T> comparer) =>
 				NotEqual(expected, actual, GetEqualityComparer<IEnumerable<T>>(new AssertEqualityComparerAdapter<T>(comparer)));
 


### PR DESCRIPTION
As far as I could tell, there is no reason that the collection equality assertions cannot allow null, given that they defer to the non-collection assertions, which allow null.