### PR TITLE
Fix for xunit/xunit#2574: Change precision for doubles

### DIFF
--- a/Sdk/ArgumentFormatter.cs
+++ b/Sdk/ArgumentFormatter.cs
@@ -178,7 +178,7 @@ namespace Xunit.Sdk
 					return $"{value:G9}";
 
 				if (value is double)
-					return $"{value:G17}";
+					return $"{value:G15}";
 
 				var type = value.GetType();
 				var typeInfo = type.GetTypeInfo();


### PR DESCRIPTION
Changing G17 to G15 fixed the issue where doubles are too precise such as in Issue [#2574](https://github.com/xunit/xunit/issues/2574)