### PR TITLE
xunit/xunit#2431 Enabled equivalence checks for reference types inside of value types

### DIFF
--- a/Sdk/AssertHelper.cs
+++ b/Sdk/AssertHelper.cs
@@ -149,10 +149,17 @@ namespace Xunit.Internal
 					return VerifyEquivalence(expectedValue, actualValue, strict, prefixDot + "Value", expectedRefs, actualRefs);
 				}
 
-				// Value types and strings should just fall back to their Equals implementation
-				if (expectedTypeInfo.IsValueType || expectedType == typeof(string))
+				// Primitive types, enums and strings should just fall back to their Equals implementation
+				if (expectedTypeInfo.IsPrimitive || expectedTypeInfo.IsEnum || expectedType == typeof(string))
 					return
 						expected.Equals(actual)
+							? null
+							: EquivalentException.ForMemberValueMismatch(expected, actual, prefix);
+
+				// IComparable value types should fall back to their CompareTo implementation
+				if (expectedTypeInfo.IsValueType && expected is IComparable expectedComparable)
+					return
+						expectedComparable.CompareTo(actual) == 0
 							? null
 							: EquivalentException.ForMemberValueMismatch(expected, actual, prefix);
 

--- a/Sdk/AssertHelper.cs
+++ b/Sdk/AssertHelper.cs
@@ -122,11 +122,15 @@ namespace Xunit.Internal
 							: EquivalentException.ForMemberValueMismatch(expected, actual, prefix);
 
 				// IComparable value types should fall back to their CompareTo implementation
-				if (expectedTypeInfo.IsValueType && expected is IComparable expectedComparable)
-					return
-						expectedComparable.CompareTo(actual) == 0
-							? null
-							: EquivalentException.ForMemberValueMismatch(expected, actual, prefix);
+				if (expectedTypeInfo.IsValueType)
+				{
+					var expectedComparable = expected as IComparable;
+					if (expectedComparable != null)
+						return
+							expectedComparable.CompareTo(actual) == 0
+								? null
+								: EquivalentException.ForMemberValueMismatch(expected, actual, prefix);
+				}
 
 				// Enumerables? Check equivalence of individual members
 				var enumerableExpected = expected as IEnumerable;

--- a/Sdk/AssertHelper.cs
+++ b/Sdk/AssertHelper.cs
@@ -113,41 +113,6 @@ namespace Xunit.Internal
 			{
 				var expectedType = expected.GetType();
 				var expectedTypeInfo = expectedType.GetTypeInfo();
-				var actualType = actual.GetType();
-				var actualTypeInfo = actualType.GetTypeInfo();
-
-				// KeyValuePair<,> should compare key and value for equivalence; since KVP is a value
-				// type, we want to avoid just calling Equals(), since it's not a good enough test of
-				// equivalence for us (we want equivalence tests for both key and value).
-				if (expectedTypeInfo.IsGenericType &&
-					expectedTypeInfo.GetGenericTypeDefinition() == typeof(KeyValuePair<,>) &&
-					actualTypeInfo.IsGenericType &&
-					actualTypeInfo.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
-				{
-					var prefixDot = prefix == string.Empty ? string.Empty : prefix + ".";
-
-					var expectedKeyGetter = expectedType.GetRuntimeProperty("Key");
-					var actualKeyGetter = actualType.GetRuntimeProperty("Key");
-					if (expectedKeyGetter == null || actualKeyGetter == null)
-						throw new InvalidOperationException("Catastrophic failure: Could not find KeyValuePair<,>.Key via reflection");
-
-					var expectedKey = expectedKeyGetter.GetValue(expected);
-					var actualKey = actualKeyGetter.GetValue(actual);
-
-					var keyResult = VerifyEquivalence(expectedKey, actualKey, strict, prefixDot + "Key", expectedRefs, actualRefs);
-					if (keyResult != null)
-						return keyResult;
-
-					var expectedValueGetter = expectedType.GetRuntimeProperty("Value");
-					var actualValueGetter = actualType.GetRuntimeProperty("Value");
-					if (expectedValueGetter == null || actualValueGetter == null)
-						throw new InvalidOperationException("Catastrophic failure: Could not find KeyValuePair<,>.Value via reflection");
-
-					var expectedValue = expectedValueGetter.GetValue(expected);
-					var actualValue = actualValueGetter.GetValue(actual);
-
-					return VerifyEquivalence(expectedValue, actualValue, strict, prefixDot + "Value", expectedRefs, actualRefs);
-				}
 
 				// Primitive types, enums and strings should just fall back to their Equals implementation
 				if (expectedTypeInfo.IsPrimitive || expectedTypeInfo.IsEnum || expectedType == typeof(string))


### PR DESCRIPTION
Fix for xunit/xunit#2431. This changes the behaviour for structs to only use `Equals` when they implement `IEquatable`. See xunit/xunit#2655 for tests.