### PR TITLE
#2621 Check that property getter in equivalence check logic is public and non-static

### DIFF
--- a/Sdk/AssertHelper.cs
+++ b/Sdk/AssertHelper.cs
@@ -44,7 +44,7 @@ namespace Xunit.Internal
 				var propertyGetters =
 					_type
 						.GetRuntimeProperties()
-						.Where(p => p.CanRead && p.GetMethod is { } getter && getter.IsPublic && !getter.IsStatic)
+						.Where(p => p.CanRead && p.GetMethod != null && p.GetMethod.IsPublic && !p.GetMethod.IsStatic)
 #if XUNIT_NULLABLE
 						.Select(p => new { name = p.Name, getter = (Func<object?, object?>)p.GetValue });
 #else

--- a/Sdk/AssertHelper.cs
+++ b/Sdk/AssertHelper.cs
@@ -43,7 +43,7 @@ namespace Xunit.Internal
 				var propertyGetters =
 					_type
 						.GetRuntimeProperties()
-						.Where(p => p.CanRead)
+						.Where(p => p.CanRead && p.GetMethod is { } getter && getter.IsPublic && !getter.IsStatic)
 #if XUNIT_NULLABLE
 						.Select(p => new { name = p.Name, getter = (Func<object?, object?>)p.GetValue });
 #else


### PR DESCRIPTION
Fixes xunit/xunit#2621. xunit/xunit#2661 adds tests.