### PR TITLE
#2534 Fix: "ArgumentFormatter doesn't pretty-print rank-1 variable-bound arrays correctly"

### DIFF
--- a/Sdk/ArgumentFormatter.cs
+++ b/Sdk/ArgumentFormatter.cs
@@ -322,7 +322,7 @@ namespace Xunit.Sdk
 		/// Extension method for IsSZArray to work downlevel 
 		/// </summary>
 		/// <param name="typeInfo">The typeInfo to be checked</param>
-		/// <returns>Whether the Type is a SZ array or not</returns>
+		/// <returns>Whether the TypeInfo is a SZ array or not</returns>
 		public static bool IsSzArrayType(this TypeInfo typeInfo)
 		{
 
@@ -341,6 +341,7 @@ namespace Xunit.Sdk
 #endif
 		}
 
+
 		static string FormatTypeName(Type type)
 		{
 			var typeInfo = type.GetTypeInfo();
@@ -348,7 +349,7 @@ namespace Xunit.Sdk
 
 			// Deconstruct and re-construct array
 			while (typeInfo.IsArray)
-			
+			{
 				if (typeInfo.IsSzArrayType())
 				{
 					arraySuffix += "[]";

--- a/Sdk/ArgumentFormatter.cs
+++ b/Sdk/ArgumentFormatter.cs
@@ -317,30 +317,16 @@ namespace Xunit.Sdk
 			return $"[{printedValues}]";
 		}
 
-
-		/// <summary>
-		/// Extension method for IsSZArray to work downlevel 
-		/// </summary>
-		/// <param name="typeInfo">The typeInfo to be checked</param>
-		/// <returns>Whether the TypeInfo is a SZ array or not</returns>
-		public static bool IsSzArrayType(this TypeInfo typeInfo)
+		static bool IsSZArrayType(this TypeInfo typeInfo)
 		{
-
 #if NETCOREAPP2_0_OR_GREATER
-			// framework built-in function
 			return typeInfo.IsSZArray;
-#else
-
-			// bounce through a few layers of indirection to detect this
-#if XUNIT_NULLABLE
+#elif XUNIT_NULLABLE
 			return typeInfo == typeInfo.GetElementType()!.MakeArrayType().GetTypeInfo();
 #else
 			return typeInfo == typeInfo.GetElementType().MakeArrayType().GetTypeInfo();
 #endif
-
-#endif
 		}
-
 
 		static string FormatTypeName(Type type)
 		{
@@ -350,21 +336,15 @@ namespace Xunit.Sdk
 			// Deconstruct and re-construct array
 			while (typeInfo.IsArray)
 			{
-				if (typeInfo.IsSzArrayType())
-				{
+				if (typeInfo.IsSZArrayType())
 					arraySuffix += "[]";
-				}
 				else
 				{
 					var rank = typeInfo.GetArrayRank();
 					if (rank == 1)
-					{
 						arraySuffix += "[*]";
-					}
 					else
-					{
 						arraySuffix += $"[{new string(',', rank - 1)}]";
-					}
 				}
 
 #if XUNIT_NULLABLE


### PR DESCRIPTION
Fix for xunit/xunit#2534

Is this issue still open? Saw there was a pull request a while aga.
I tested it and it works, however it doesn't have a call to IsSZArray as requested in Sample Fix and isn't implemented as an extension method to work downlevel.

Anyway I made a fix for the issue that makes a call to IsSZArray and also works downlevel incase IsSZArray is not available due to .NET Version

Let me know what you think of the fix. And if any further improvements are required.