### PR TITLE
Fix  #2671: assert contains behaves unexpected on ISet and IDictionary

### DIFF
--- a/CollectionAsserts.cs
+++ b/CollectionAsserts.cs
@@ -491,6 +491,23 @@ namespace Xunit
 		}
 
 		/// <summary>
+		/// Verifies that a collection does not contain a given item. This function behaves identical to !ISet.Contains.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be compared</typeparam>
+		/// <param name="expected">The object that is expected not to be in the collection</param>
+		/// <param name="collection">The collection to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the object is present inside the container</exception>
+		public static void DoesNotContain<T>(
+			T expected,
+			ISet<T> collection)
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+			// Do not forward to DoesNotContain(expected, collection.Keys) as we want the default SDK behavior
+			if (collection.Contains(expected))
+				throw new DoesNotContainException(expected, collection);
+		}
+
+		/// <summary>
 		/// Verifies that a collection is empty.
 		/// </summary>
 		/// <param name="collection">The collection to be inspected</param>

--- a/CollectionAsserts.cs
+++ b/CollectionAsserts.cs
@@ -465,8 +465,9 @@ namespace Xunit
 		{
 			GuardArgumentNotNull(nameof(expected), expected);
 			GuardArgumentNotNull(nameof(collection), collection);
-
-			DoesNotContain(expected, collection.Keys);
+			// Do not forward to DoesNotContain(expected, collection.Keys) as we want the default SDK behavior
+			if (collection.ContainsKey(expected))
+				throw new ContainsException(expected, collection.Keys);
 		}
 
 		/// <summary>
@@ -486,8 +487,9 @@ namespace Xunit
 		{
 			GuardArgumentNotNull(nameof(expected), expected);
 			GuardArgumentNotNull(nameof(collection), collection);
-
-			DoesNotContain(expected, collection.Keys);
+			// Do not forward to DoesNotContain(expected, collection.Keys) as we want the default SDK behavior
+			if (collection.ContainsKey(expected))
+				throw new ContainsException(expected, collection.Keys);
 		}
 
 		/// <summary>

--- a/CollectionAsserts.cs
+++ b/CollectionAsserts.cs
@@ -285,6 +285,23 @@ namespace Xunit
 		}
 
 		/// <summary>
+		/// Verifies that a collection contains a given object. This function behaves identical to ISet.Contains.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="expected">The object expected to be in the collection</param>
+		/// <param name="collection">The collection to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the collection</exception>
+		public static void Contains<T>(
+			T expected,
+			ISet<T> collection)
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+			// Do not forward to DoesNotContain(expected, collection.Keys) as we want the default SDK behavior
+			if (!collection.Contains(expected))
+				throw new ContainsException(expected, collection);
+		}
+
+		/// <summary>
 		/// Verifies that a dictionary contains a given key.
 		/// </summary>
 		/// <typeparam name="TKey">The type of the keys of the object to be verified.</typeparam>

--- a/DictionaryAsserts.cs
+++ b/DictionaryAsserts.cs
@@ -1,0 +1,235 @@
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Xunit.Sdk;
+
+#if XUNIT_IMMUTABLE_COLLECTIONS
+using System.Collections.Immutable;
+#endif
+
+namespace Xunit
+{
+#if XUNIT_VISIBILITY_INTERNAL
+	internal
+#else
+	public
+#endif
+	partial class Assert
+	{
+		/// <summary>
+		/// Verifies that a dictionary contains a given key.
+		/// </summary>
+		/// <typeparam name="TKey">The type of the keys of the object to be verified.</typeparam>
+		/// <typeparam name="TValue">The type of the values of the object to be verified.</typeparam>
+		/// <param name="expected">The object expected to be in the collection.</param>
+		/// <param name="collection">The collection to be inspected.</param>
+		/// <returns>The value associated with <paramref name="expected"/>.</returns>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the collection</exception>
+		public static TValue Contains<TKey, TValue>(
+			TKey expected,
+			IDictionary<TKey, TValue> collection)
+#if XUNIT_NULLABLE
+				where TKey : notnull
+#endif
+		{
+			GuardArgumentNotNull(nameof(expected), expected);
+			GuardArgumentNotNull(nameof(collection), collection);
+
+			var value = default(TValue);
+			if (!collection.TryGetValue(expected, out value))
+				throw new ContainsException(expected, collection.Keys);
+
+			return value;
+		}
+
+		/// <summary>
+		/// Verifies that a read-only dictionary contains a given key.
+		/// </summary>
+		/// <typeparam name="TKey">The type of the keys of the object to be verified.</typeparam>
+		/// <typeparam name="TValue">The type of the values of the object to be verified.</typeparam>
+		/// <param name="expected">The object expected to be in the collection.</param>
+		/// <param name="collection">The collection to be inspected.</param>
+		/// <returns>The value associated with <paramref name="expected"/>.</returns>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the collection</exception>
+		public static TValue Contains<TKey, TValue>(
+			TKey expected,
+			IReadOnlyDictionary<TKey, TValue> collection)
+#if XUNIT_NULLABLE
+				where TKey : notnull
+#endif
+		{
+			GuardArgumentNotNull(nameof(expected), expected);
+			GuardArgumentNotNull(nameof(collection), collection);
+
+			var value = default(TValue);
+			if (!collection.TryGetValue(expected, out value))
+				throw new ContainsException(expected, collection.Keys);
+
+			return value;
+		}
+
+		/// <summary>
+		/// Verifies that a dictionary contains a given key.
+		/// </summary>
+		/// <typeparam name="TKey">The type of the keys of the object to be verified.</typeparam>
+		/// <typeparam name="TValue">The type of the values of the object to be verified.</typeparam>
+		/// <param name="expected">The object expected to be in the collection.</param>
+		/// <param name="collection">The collection to be inspected.</param>
+		/// <returns>The value associated with <paramref name="expected"/>.</returns>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the collection</exception>
+		public static TValue Contains<TKey, TValue>(
+			TKey expected,
+			Dictionary<TKey, TValue> collection)
+#if XUNIT_NULLABLE
+				where TKey : notnull
+#endif
+		{
+			return Contains(expected, (IReadOnlyDictionary<TKey, TValue>)collection);
+		}
+
+		/// <summary>
+		/// Verifies that a dictionary contains a given key.
+		/// </summary>
+		/// <typeparam name="TKey">The type of the keys of the object to be verified.</typeparam>
+		/// <typeparam name="TValue">The type of the values of the object to be verified.</typeparam>
+		/// <param name="expected">The object expected to be in the collection.</param>
+		/// <param name="collection">The collection to be inspected.</param>
+		/// <returns>The value associated with <paramref name="expected"/>.</returns>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the collection</exception>
+		public static TValue Contains<TKey, TValue>(
+			TKey expected,
+			ReadOnlyDictionary<TKey, TValue> collection)
+#if XUNIT_NULLABLE
+				where TKey : notnull
+#endif
+		{
+			return Contains(expected, (IReadOnlyDictionary<TKey, TValue>)collection);
+		}
+
+#if XUNIT_IMMUTABLE_COLLECTIONS
+		/// <summary>
+		/// Verifies that a dictionary contains a given key.
+		/// </summary>
+		/// <typeparam name="TKey">The type of the keys of the object to be verified.</typeparam>
+		/// <typeparam name="TValue">The type of the values of the object to be verified.</typeparam>
+		/// <param name="expected">The object expected to be in the collection.</param>
+		/// <param name="collection">The collection to be inspected.</param>
+		/// <returns>The value associated with <paramref name="expected"/>.</returns>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the collection</exception>
+		public static TValue Contains<TKey, TValue>(
+			TKey expected,
+			ImmutableDictionary<TKey, TValue> collection)
+#if XUNIT_NULLABLE
+				where TKey : notnull
+#endif
+		{
+			return Contains(expected, (IReadOnlyDictionary<TKey, TValue>)collection);
+		}
+#endif
+
+		/// <summary>
+		/// Verifies that a dictionary does not contain a given key.
+		/// </summary>
+		/// <typeparam name="TKey">The type of the keys of the object to be verified.</typeparam>
+		/// <typeparam name="TValue">The type of the values of the object to be verified.</typeparam>
+		/// <param name="expected">The object expected to be in the collection.</param>
+		/// <param name="collection">The collection to be inspected.</param>
+		/// <exception cref="DoesNotContainException">Thrown when the object is present in the collection</exception>
+		public static void DoesNotContain<TKey, TValue>(
+			TKey expected,
+			IDictionary<TKey, TValue> collection)
+#if XUNIT_NULLABLE
+				where TKey : notnull
+#endif
+		{
+			GuardArgumentNotNull(nameof(expected), expected);
+			GuardArgumentNotNull(nameof(collection), collection);
+
+			// Do not forward to DoesNotContain(expected, collection.Keys) as we want the default SDK behavior
+			if (collection.ContainsKey(expected))
+				throw new DoesNotContainException(expected, collection.Keys);
+		}
+
+		/// <summary>
+		/// Verifies that a dictionary does not contain a given key.
+		/// </summary>
+		/// <typeparam name="TKey">The type of the keys of the object to be verified.</typeparam>
+		/// <typeparam name="TValue">The type of the values of the object to be verified.</typeparam>
+		/// <param name="expected">The object expected to be in the collection.</param>
+		/// <param name="collection">The collection to be inspected.</param>
+		/// <exception cref="DoesNotContainException">Thrown when the object is present in the collection</exception>
+		public static void DoesNotContain<TKey, TValue>(
+			TKey expected,
+			IReadOnlyDictionary<TKey, TValue> collection)
+#if XUNIT_NULLABLE
+				where TKey : notnull
+#endif
+		{
+			GuardArgumentNotNull(nameof(expected), expected);
+			GuardArgumentNotNull(nameof(collection), collection);
+
+			// Do not forward to DoesNotContain(expected, collection.Keys) as we want the default SDK behavior
+			if (collection.ContainsKey(expected))
+				throw new DoesNotContainException(expected, collection.Keys);
+		}
+
+		/// <summary>
+		/// Verifies that a dictionary does not contain a given key.
+		/// </summary>
+		/// <typeparam name="TKey">The type of the keys of the object to be verified.</typeparam>
+		/// <typeparam name="TValue">The type of the values of the object to be verified.</typeparam>
+		/// <param name="expected">The object expected to be in the collection.</param>
+		/// <param name="collection">The collection to be inspected.</param>
+		/// <exception cref="DoesNotContainException">Thrown when the object is present in the collection</exception>
+		public static void DoesNotContain<TKey, TValue>(
+			TKey expected,
+			Dictionary<TKey, TValue> collection)
+#if XUNIT_NULLABLE
+				where TKey : notnull
+#endif
+		{
+			DoesNotContain(expected, (IDictionary<TKey, TValue>)collection);
+		}
+
+		/// <summary>
+		/// Verifies that a dictionary does not contain a given key.
+		/// </summary>
+		/// <typeparam name="TKey">The type of the keys of the object to be verified.</typeparam>
+		/// <typeparam name="TValue">The type of the values of the object to be verified.</typeparam>
+		/// <param name="expected">The object expected to be in the collection.</param>
+		/// <param name="collection">The collection to be inspected.</param>
+		/// <exception cref="DoesNotContainException">Thrown when the object is present in the collection</exception>
+		public static void DoesNotContain<TKey, TValue>(
+			TKey expected,
+			ReadOnlyDictionary<TKey, TValue> collection)
+#if XUNIT_NULLABLE
+				where TKey : notnull
+#endif
+		{
+			DoesNotContain(expected, (IReadOnlyDictionary<TKey, TValue>)collection);
+		}
+
+#if XUNIT_IMMUTABLE_COLLECTIONS
+		/// <summary>
+		/// Verifies that a dictionary does not contain a given key.
+		/// </summary>
+		/// <typeparam name="TKey">The type of the keys of the object to be verified.</typeparam>
+		/// <typeparam name="TValue">The type of the values of the object to be verified.</typeparam>
+		/// <param name="expected">The object expected to be in the collection.</param>
+		/// <param name="collection">The collection to be inspected.</param>
+		/// <exception cref="DoesNotContainException">Thrown when the object is present in the collection</exception>
+		public static void DoesNotContain<TKey, TValue>(
+			TKey expected,
+			ImmutableDictionary<TKey, TValue> collection)
+#if XUNIT_NULLABLE
+				where TKey : notnull
+#endif
+		{
+			DoesNotContain(expected, (IReadOnlyDictionary<TKey, TValue>)collection);
+		}
+#endif
+	}
+}

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ To open an issue for this project, please visit the [core xUnit.net project issu
 
 The following pre-processor directives can be used to influence the resulting code contained in this repository:
 
+### `XUNIT_IMMUTABLE_COLLECTIONS` (min: C# 6.0, xUnit.net v2)
+
+There are assertions that target immutable collections. If you are using a target framework that is compatible with [`System.Collections.Immutable`](https://www.nuget.org/packages/System.Collections.Immutable), you should define `XUNIT_IMMUTABLE_COLLECTIONS` to enable the additional versions of those assertions that will consume immutable collections.
+
 ### `XUNIT_NULLABLE` (min: C# 9.0, xUnit.net v2)
 
 Projects that consume this repository as source, which wish to use nullable reference type annotations should define the `XUNIT_NULLABLE` compilation symbol to opt-in to the relevant nullability analysis annotations on method signatures.

--- a/SetAsserts.cs
+++ b/SetAsserts.cs
@@ -5,6 +5,10 @@
 using System.Collections.Generic;
 using Xunit.Sdk;
 
+#if XUNIT_IMMUTABLE_COLLECTIONS
+using System.Collections.Immutable;
+#endif
+
 namespace Xunit
 {
 #if XUNIT_VISIBILITY_INTERNAL
@@ -15,16 +19,144 @@ namespace Xunit
 	partial class Assert
 	{
 		/// <summary>
+		/// Verifies that the set contains the given object.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="expected">The object expected to be in the set</param>
+		/// <param name="set">The set to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the set</exception>
+		public static void Contains<T>(
+			T expected,
+			ISet<T> set)
+		{
+			GuardArgumentNotNull(nameof(set), set);
+
+			// Do not forward to DoesNotContain(expected, set.Keys) as we want the default SDK behavior
+			if (!set.Contains(expected))
+				throw new ContainsException(expected, set);
+		}
+
+#if NET5_0_OR_GREATER
+		/// <summary>
+		/// Verifies that the read-only set contains the given object.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="expected">The object expected to be in the set</param>
+		/// <param name="set">The set to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the set</exception>
+		public static void Contains<T>(
+			T expected,
+			IReadOnlySet<T> set)
+		{
+			GuardArgumentNotNull(nameof(set), set);
+
+			// Do not forward to DoesNotContain(expected, set.Keys) as we want the default SDK behavior
+			if (!set.Contains(expected))
+				throw new ContainsException(expected, set);
+		}
+#endif
+
+		/// <summary>
+		/// Verifies that the hashset contains the given object.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="expected">The object expected to be in the set</param>
+		/// <param name="set">The set to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the set</exception>
+		public static void Contains<T>(
+			T expected,
+			HashSet<T> set) =>
+				Contains(expected, (ISet<T>)set);
+
+#if XUNIT_IMMUTABLE_COLLECTIONS
+		/// <summary>
+		/// Verifies that the immutable hashset contains the given object.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="expected">The object expected to be in the set</param>
+		/// <param name="set">The set to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the set</exception>
+		public static void Contains<T>(
+			T expected,
+			ImmutableHashSet<T> set) =>
+				Contains(expected, (ISet<T>)set);
+#endif
+
+		/// <summary>
+		/// Verifies that the set does not contain the given item.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be compared</typeparam>
+		/// <param name="expected">The object that is expected not to be in the set</param>
+		/// <param name="set">The set to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the object is present inside the set</exception>
+		public static void DoesNotContain<T>(
+			T expected,
+			ISet<T> set)
+		{
+			GuardArgumentNotNull(nameof(set), set);
+
+			if (set.Contains(expected))
+				throw new DoesNotContainException(expected, set);
+		}
+
+#if NET5_0_OR_GREATER
+		/// <summary>
+		/// Verifies that the read-only set does not contain the given item.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be compared</typeparam>
+		/// <param name="expected">The object that is expected not to be in the set</param>
+		/// <param name="set">The set to be inspected</param>
+		/// <exception cref="DoesNotContainException">Thrown when the object is present inside the container</exception>
+		public static void DoesNotContain<T>(
+			T expected,
+			IReadOnlySet<T> set)
+		{
+			GuardArgumentNotNull(nameof(set), set);
+
+			if (set.Contains(expected))
+				throw new DoesNotContainException(expected, set);
+		}
+#endif
+
+		/// <summary>
+		/// Verifies that the hashset does not contain the given item.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="expected">The object expected to be in the set</param>
+		/// <param name="set">The set to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the set</exception>
+		public static void DoesNotContain<T>(
+			T expected,
+			HashSet<T> set) =>
+				DoesNotContain(expected, (ISet<T>)set);
+
+#if XUNIT_IMMUTABLE_COLLECTIONS
+		/// <summary>
+		/// Verifies that the immutable hashset does not contain the given item.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="expected">The object expected to be in the set</param>
+		/// <param name="set">The set to be inspected</param>
+		/// <exception cref="ContainsException">Thrown when the object is not present in the set</exception>
+		public static void DoesNotContain<T>(
+			T expected,
+			ImmutableHashSet<T> set) =>
+				DoesNotContain(expected, (ISet<T>)set);
+#endif
+
+		/// <summary>
 		/// Verifies that a set is a proper subset of another set.
 		/// </summary>
 		/// <typeparam name="T">The type of the object to be verified</typeparam>
 		/// <param name="expectedSuperset">The expected superset</param>
 		/// <param name="actual">The set expected to be a proper subset</param>
 		/// <exception cref="ContainsException">Thrown when the actual set is not a proper subset of the expected set</exception>
+		public static void ProperSubset<T>(
+			ISet<T> expectedSuperset,
 #if XUNIT_NULLABLE
-		public static void ProperSubset<T>(ISet<T> expectedSuperset, ISet<T>? actual)
+			ISet<T>? actual)
 #else
-		public static void ProperSubset<T>(ISet<T> expectedSuperset, ISet<T> actual)
+			ISet<T> actual)
 #endif
 		{
 			GuardArgumentNotNull(nameof(expectedSuperset), expectedSuperset);
@@ -40,10 +172,12 @@ namespace Xunit
 		/// <param name="expectedSubset">The expected subset</param>
 		/// <param name="actual">The set expected to be a proper superset</param>
 		/// <exception cref="ContainsException">Thrown when the actual set is not a proper superset of the expected set</exception>
+		public static void ProperSuperset<T>(
+			ISet<T> expectedSubset,
 #if XUNIT_NULLABLE
-		public static void ProperSuperset<T>(ISet<T> expectedSubset, ISet<T>? actual)
+			ISet<T>? actual)
 #else
-		public static void ProperSuperset<T>(ISet<T> expectedSubset, ISet<T> actual)
+			ISet<T> actual)
 #endif
 		{
 			GuardArgumentNotNull(nameof(expectedSubset), expectedSubset);
@@ -59,10 +193,12 @@ namespace Xunit
 		/// <param name="expectedSuperset">The expected superset</param>
 		/// <param name="actual">The set expected to be a subset</param>
 		/// <exception cref="ContainsException">Thrown when the actual set is not a subset of the expected set</exception>
+		public static void Subset<T>(
+			ISet<T> expectedSuperset,
 #if XUNIT_NULLABLE
-		public static void Subset<T>(ISet<T> expectedSuperset, ISet<T>? actual)
+			ISet<T>? actual)
 #else
-		public static void Subset<T>(ISet<T> expectedSuperset, ISet<T> actual)
+			ISet<T> actual)
 #endif
 		{
 			GuardArgumentNotNull(nameof(expectedSuperset), expectedSuperset);
@@ -78,10 +214,12 @@ namespace Xunit
 		/// <param name="expectedSubset">The expected subset</param>
 		/// <param name="actual">The set expected to be a superset</param>
 		/// <exception cref="ContainsException">Thrown when the actual set is not a superset of the expected set</exception>
+		public static void Superset<T>(
+			ISet<T> expectedSubset,
 #if XUNIT_NULLABLE
-		public static void Superset<T>(ISet<T> expectedSubset, ISet<T>? actual)
+			ISet<T>? actual)
 #else
-		public static void Superset<T>(ISet<T> expectedSubset, ISet<T> actual)
+			ISet<T> actual)
 #endif
 		{
 			GuardArgumentNotNull(nameof(expectedSubset), expectedSubset);


### PR DESCRIPTION
Hi,

this is my PR for [#2671](https://github.com/xunit/xunit/issues/2671).  Unfortunately I am failing to build xUnit v2 from VS2022 even though I followed the steps in the Readme. 

.\build.ps1 works fine and tells me that expectedly 2 unit tests are failing: 
 CollectionAssertsTests+DoesNotContain.KeyInReadOnlyDictionary [FAIL]
      Assert.IsType() Failure
      Expected: Xunit.Sdk.DoesNotContainException
      Actual:   Xunit.Sdk.ContainsException
      Stack Trace:
        test\test.xunit.assert\Asserts\CollectionAssertsTests.cs(753,0): at CollectionAssertsTests.DoesNotContain.KeyInReadOnlyDictionary()
    CollectionAssertsTests+DoesNotContain.KeyInDictionary [FAIL]
      Assert.IsType() Failure
      Expected: Xunit.Sdk.DoesNotContainException
      Actual:   Xunit.Sdk.ContainsException
      Stack Trace:
        test\test.xunit.assert\Asserts\CollectionAssertsTests.cs(721,0): at CollectionAssertsTests.DoesNotContain.KeyInDictionary()

Maybe someone can pick up my work over here or tell me how to compile and run the tests in VS 2022.