### PR TITLE
Add Assert.NotRaisedAny and NotRaisedAnyAsync methods (#3239)

### DIFF
--- a/EventAsserts.cs
+++ b/EventAsserts.cs
@@ -470,6 +470,129 @@ namespace Xunit
 		}
 
 		/// <summary>
+		/// Verifies that an event is not raised.
+		/// </summary>
+		/// <param name="attach">Code to attach the event handler</param>
+		/// <param name="detach">Code to detach the event handler</param>
+		/// <param name="testCode">A delegate to the code to be tested</param>
+		/// <exception cref="NotRaisesException">Thrown when an unexpected event was raised.</exception>
+		public static void NotRaisedAny(
+			Action<Action> attach,
+			Action<Action> detach,
+			Action testCode)
+		{
+			GuardArgumentNotNull(nameof(attach), attach);
+			GuardArgumentNotNull(nameof(detach), detach);
+			GuardArgumentNotNull(nameof(testCode), testCode);
+
+			if (RaisesInternal(attach, detach, testCode))
+				throw NotRaisesException.ForUnexpectedEvent();
+		}
+
+		/// <summary>
+		/// Verifies that an event with the exact or a derived event args is not raised.
+		/// </summary>
+		/// <typeparam name="T">The type of the event arguments to expect</typeparam>
+		/// <param name="attach">Code to attach the event handler</param>
+		/// <param name="detach">Code to detach the event handler</param>
+		/// <param name="testCode">A delegate to the code to be tested</param>
+		/// <exception cref="NotRaisesException">Thrown when an unexpected event was raised.</exception>
+		public static void NotRaisedAny<T>(
+			Action<Action<T>> attach,
+			Action<Action<T>> detach,
+			Action testCode)
+		{
+			GuardArgumentNotNull(nameof(attach), attach);
+			GuardArgumentNotNull(nameof(detach), detach);
+			GuardArgumentNotNull(nameof(testCode), testCode);
+
+			if (RaisesInternal(attach, detach, testCode) != null)
+				throw NotRaisesException.ForUnexpectedEvent(typeof(T));
+		}
+
+		/// <summary>
+		/// Verifies that an event with the exact or a derived event args is not raised.
+		/// </summary>
+		/// <typeparam name="T">The type of the event arguments to expect</typeparam>
+		/// <param name="attach">Code to attach the event handler</param>
+		/// <param name="detach">Code to detach the event handler</param>
+		/// <param name="testCode">A delegate to the code to be tested</param>
+		/// <exception cref="NotRaisesException">Thrown when an unexpected event was raised.</exception>
+		public static void NotRaisedAny<T>(
+			Action<EventHandler<T>> attach,
+			Action<EventHandler<T>> detach,
+			Action testCode)
+		{
+			GuardArgumentNotNull(nameof(attach), attach);
+			GuardArgumentNotNull(nameof(detach), detach);
+			GuardArgumentNotNull(nameof(testCode), testCode);
+
+			if (RaisesInternal(attach, detach, testCode) != null)
+				throw NotRaisesException.ForUnexpectedEvent(typeof(T));
+		}
+
+		/// <summary>
+		/// Verifies that an event is not raised.
+		/// </summary>
+		/// <param name="attach">Code to attach the event handler</param>
+		/// <param name="detach">Code to detach the event handler</param>
+		/// <param name="testCode">A delegate to the code to be tested</param>
+		/// <exception cref="NotRaisesException">Thrown when an unexpected event was raised.</exception>
+		public static async Task NotRaisedAnyAsync(
+			Action<Action> attach,
+			Action<Action> detach,
+			Func<Task> testCode)
+		{
+			GuardArgumentNotNull(nameof(attach), attach);
+			GuardArgumentNotNull(nameof(detach), detach);
+			GuardArgumentNotNull(nameof(testCode), testCode);
+
+			if (await RaisesAsyncInternal(attach, detach, testCode))
+				throw NotRaisesException.ForUnexpectedEvent();
+		}
+
+		/// <summary>
+		/// Verifies that an event with the exact or a derived event args is not raised.
+		/// </summary>
+		/// <typeparam name="T">The type of the event arguments to expect</typeparam>
+		/// <param name="attach">Code to attach the event handler</param>
+		/// <param name="detach">Code to detach the event handler</param>
+		/// <param name="testCode">A delegate to the code to be tested</param>
+		/// <exception cref="NotRaisesException">Thrown when an unexpected event was raised.</exception>
+		public static async Task NotRaisedAnyAsync<T>(
+			Action<Action<T>> attach,
+			Action<Action<T>> detach,
+			Func<Task> testCode)
+		{
+			GuardArgumentNotNull(nameof(attach), attach);
+			GuardArgumentNotNull(nameof(detach), detach);
+			GuardArgumentNotNull(nameof(testCode), testCode);
+			if (await RaisesAsyncInternal(attach, detach, testCode) != null)
+				throw NotRaisesException.ForUnexpectedEvent(typeof(T));
+		}
+
+		/// <summary>
+		/// Verifies that an event with the exact or a derived event args is not raised.
+		/// </summary>
+		/// <typeparam name="T">The type of the event arguments to expect</typeparam>
+		/// <param name="attach">Code to attach the event handler</param>
+		/// <param name="detach">Code to detach the event handler</param>
+		/// <param name="testCode">A delegate to the code to be tested</param>
+		/// <exception cref="NotRaisesException">Thrown when an unexpected event was raised.</exception>
+		public static async Task NotRaisedAnyAsync<T>(
+			Action<EventHandler<T>> attach,
+			Action<EventHandler<T>> detach,
+			Func<Task> testCode)
+		{
+			GuardArgumentNotNull(nameof(attach), attach);
+			GuardArgumentNotNull(nameof(detach), detach);
+			GuardArgumentNotNull(nameof(testCode), testCode);
+
+			if (await RaisesAsyncInternal(attach, detach, testCode) != null)
+				throw NotRaisesException.ForUnexpectedEvent(typeof(T));
+		}
+
+		/// <summary>
 		/// Represents a raised event after the fact.
 		/// </summary>
 		/// <typeparam name="T">The type of the event arguments.</typeparam>

--- a/Sdk/Exceptions/NotRaisesException.cs
+++ b/Sdk/Exceptions/NotRaisesException.cs
@@ -1,0 +1,50 @@
+#pragma warning disable CA1032 // Implement standard exception constructors
+#pragma warning disable IDE0090 // Use 'new(...)'
+
+#if XUNIT_NULLABLE
+#nullable enable
+#endif
+
+using System;
+using System.Globalization;
+
+namespace Xunit.Sdk
+{
+	/// <summary>
+	/// Exception thrown when Assert.NotRaisedAny fails.
+	/// </summary>
+#if XUNIT_VISIBILITY_INTERNAL
+    internal
+#else
+	public
+#endif
+	partial class NotRaisesException : XunitException
+	{
+		NotRaisesException(string message) :
+			base(message)
+		{ }
+
+		/// <summary>
+		/// Creates a new instance of the <see cref="NotRaisesException" /> class to be thrown when
+		/// an unexpected event was raised.
+		/// </summary>
+		public static NotRaisesException ForUnexpectedEvent() =>
+			new NotRaisesException("Assert.NotRaisedAny() Failure: An unexpected event was raised");
+
+		/// <summary>
+		/// Creates a new instance of the <see cref="NotRaisesException" /> class to be thrown when
+		/// an unexpected event (with data) was raised.
+		/// </summary>
+		/// <param name="unexpected">The type of the event args that was unexpected</param>
+		public static NotRaisesException ForUnexpectedEvent(Type unexpected) =>
+			new NotRaisesException(
+				string.Format(
+					CultureInfo.CurrentCulture,
+					"Assert.NotRaisedAny() Failure: An unexpected event was raised{0}Unexpected: {1}{2}Actual:   An event was raised",
+					Environment.NewLine,
+					ArgumentFormatter.Format(Assert.GuardArgumentNotNull(nameof(unexpected), unexpected)),
+					Environment.NewLine
+				)
+			);
+	}
+}


### PR DESCRIPTION
# Add Assert.NotRaisedAny and Assert.NotRaisedAnyAsync

This pull request introduces new assertions to verify that no events are raised during the execution of test code.

## Summary

- Added `Assert.NotRaisedAny` and `Assert.NotRaisedAnyAsync` methods.
- Supports the following overloads:
  - `Action`
  - `Action<T>`
  - `EventHandler<T>`
- These methods throw a `NotRaisesException` if any unexpected event is raised, with clear and informative exception messages (including the type of unexpected event when applicable).

## Tests

- Comprehensive test coverage added for all overloads.
- Includes both synchronous and asynchronous scenarios.
- Validates behavior when events are and are not raised.
- All tests are passing and behavior has been verified across all supported delegate types.
