### PR TITLE
Added an overload for All and AllAsync asserts to allow the caller to specify if test should fail if the collection is empty. 

### DIFF
--- a/CollectionAsserts.cs
+++ b/CollectionAsserts.cs
@@ -41,7 +41,7 @@ namespace Xunit
 			GuardArgumentNotNull(nameof(collection), collection);
 			GuardArgumentNotNull(nameof(action), action);
 
-			All(collection, (item, index) => action(item));
+			All(collection, (item, index) => action(item), throwIfEmpty: false);
 		}
 
 		/// <summary>
@@ -62,10 +62,7 @@ namespace Xunit
 			GuardArgumentNotNull(nameof(collection), collection);
 			GuardArgumentNotNull(nameof(action), action);
 
-			if (throwIfEmpty && !collection.Any())
-				throw AllException.ForEmptyCollection();
-
-			All(collection, (item, index) => action(item));
+			All(collection, (item, index) => action(item), throwIfEmpty);
 		}
 
 		/// <summary>
@@ -79,6 +76,27 @@ namespace Xunit
 		public static void All<T>(
 			IEnumerable<T> collection,
 			Action<T, int> action)
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+			GuardArgumentNotNull(nameof(action), action);
+
+			All(collection, action, throwIfEmpty: false);
+		}
+
+		/// <summary>
+		/// Verifies that all items in the collection pass when executed against
+		/// action. The item index is provided to the action, in addition to the item.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="collection">The collection</param>
+		/// <param name="action">The action to test each item against</param>
+		/// <param name="throwIfEmpty">Indicates whether to throw an exception if the collection is empty</param>
+		/// <exception cref="AllException">Thrown when the collection contains at least one non-matching element</exception>
+		/// <exception cref="AllException">Also thrown when collection is empty and <paramref name="throwIfEmpty"/> is set to true</exception>
+		public static void All<T>(
+			IEnumerable<T> collection,
+			Action<T, int> action,
+			bool throwIfEmpty)
 		{
 			GuardArgumentNotNull(nameof(collection), collection);
 			GuardArgumentNotNull(nameof(action), action);
@@ -100,6 +118,9 @@ namespace Xunit
 				++idx;
 			}
 
+			if (throwIfEmpty && idx == 0)
+				throw AllException.ForEmptyCollection();
+
 			if (errors.Count > 0)
 				throw AllException.ForFailures(idx, errors);
 		}
@@ -119,7 +140,7 @@ namespace Xunit
 			GuardArgumentNotNull(nameof(collection), collection);
 			GuardArgumentNotNull(nameof(action), action);
 
-			await AllAsync(collection, async (item, index) => await action(item));
+			await AllAsync(collection, async (item, index) => await action(item), throwIfEmpty: false);
 		}
 
 		/// <summary>
@@ -140,10 +161,7 @@ namespace Xunit
 			GuardArgumentNotNull(nameof(collection), collection);
 			GuardArgumentNotNull(nameof(action), action);
 
-			if (throwIfEmpty && !collection.Any())
-				throw AllException.ForEmptyCollection();
-
-			await AllAsync(collection, (item, index) => action(item));
+			await AllAsync(collection, (item, index) => action(item), throwIfEmpty);
 		}
 
 		/// <summary>
@@ -157,6 +175,27 @@ namespace Xunit
 		public static async Task AllAsync<T>(
 			IEnumerable<T> collection,
 			Func<T, int, Task> action)
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+			GuardArgumentNotNull(nameof(action), action);
+
+			await AllAsync(collection, action, throwIfEmpty: false);
+		}
+
+		/// <summary>
+		/// Verifies that all items in the collection pass when executed against
+		/// action. The item index is provided to the action, in addition to the item.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="collection">The collection</param>
+		/// <param name="action">The action to test each item against</param>
+		/// <param name="throwIfEmpty">Indicates whether to throw an exception if the collection is empty</param>
+		/// <exception cref="AllException">Thrown when the collection contains at least one non-matching element</exception>
+		/// <exception cref="AllException">Also thrown when collection is empty and <paramref name="throwIfEmpty"/> is set to true</exception>
+		public static async Task AllAsync<T>(
+			IEnumerable<T> collection,
+			Func<T, int, Task> action,
+			bool throwIfEmpty)
 		{
 			GuardArgumentNotNull(nameof(collection), collection);
 			GuardArgumentNotNull(nameof(action), action);
@@ -177,6 +216,9 @@ namespace Xunit
 
 				++idx;
 			}
+
+			if (throwIfEmpty && idx == 0)
+				throw AllException.ForEmptyCollection();
 
 			if (errors.Count > 0)
 				throw AllException.ForFailures(idx, errors.ToArray());

--- a/CollectionAsserts.cs
+++ b/CollectionAsserts.cs
@@ -46,6 +46,30 @@ namespace Xunit
 
 		/// <summary>
 		/// Verifies that all items in the collection pass when executed against
+		/// action.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="collection">The collection</param>
+		/// <param name="action">The action to test each item against</param>
+		/// <param name="throwIfEmpty">Indicates whether to throw an exception if the collection is empty</param>
+		/// <exception cref="AllException">Thrown when the collection contains at least one non-matching element</exception>
+		/// <exception cref="AllException">Also thrown when collection is empty and <paramref name="throwIfEmpty"/> is set to true</exception>
+		public static void All<T>(
+			IEnumerable<T> collection,
+			Action<T> action,
+			bool throwIfEmpty)
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+			GuardArgumentNotNull(nameof(action), action);
+
+			if (throwIfEmpty && !collection.Any())
+				throw AllException.ForEmptyCollection();
+
+			All(collection, (item, index) => action(item));
+		}
+
+		/// <summary>
+		/// Verifies that all items in the collection pass when executed against
 		/// action. The item index is provided to the action, in addition to the item.
 		/// </summary>
 		/// <typeparam name="T">The type of the object to be verified</typeparam>
@@ -96,6 +120,30 @@ namespace Xunit
 			GuardArgumentNotNull(nameof(action), action);
 
 			await AllAsync(collection, async (item, index) => await action(item));
+		}
+
+		/// <summary>
+		/// Verifies that all items in the collection pass when executed against
+		/// action.
+		/// </summary>
+		/// <typeparam name="T">The type of the object to be verified</typeparam>
+		/// <param name="collection">The collection</param>
+		/// <param name="action">The action to test each item against</param>
+		/// <param name="throwIfEmpty">Indicates whether to throw an exception if the collection is empty</param>
+		/// <exception cref="AllException">Thrown when the collection contains at least one non-matching element</exception>
+		/// <exception cref="AllException">Also thrown when collection is empty and <paramref name="throwIfEmpty"/> is set to true</exception>
+		public static async Task AllAsync<T>(
+			IEnumerable<T> collection,
+			Func<T, Task> action,
+			bool throwIfEmpty)
+		{
+			GuardArgumentNotNull(nameof(collection), collection);
+			GuardArgumentNotNull(nameof(action), action);
+
+			if (throwIfEmpty && !collection.Any())
+				throw AllException.ForEmptyCollection();
+
+			await AllAsync(collection, (item, index) => action(item));
 		}
 
 		/// <summary>

--- a/Sdk/Exceptions/AllException.cs
+++ b/Sdk/Exceptions/AllException.cs
@@ -79,5 +79,20 @@ namespace Xunit.Sdk
 
 			return new AllException(message);
 		}
+
+		/// <summary>
+		/// Creates a new instance of the <see cref="AllException"/> class to be thrown when
+		/// collection is not supposed to be empty
+		/// during <see cref="Assert.All{T}(IEnumerable{T}, Action{T}, bool)"/>
+		/// or <see cref="Assert.AllAsync{T}(IEnumerable{T}, Func{T, Task}, bool)"/>.
+		/// </summary>
+		public static AllException ForEmptyCollection() =>
+			new AllException(
+				string.Format(
+					CultureInfo.CurrentCulture,
+					"Assert.All() Failure: The collection was empty.{0}At least one item was expected.",
+					Environment.NewLine
+				)
+			);
 	}
 }


### PR DESCRIPTION
Following the [idea](https://github.com/xunit/xunit/discussions/3473) I suggested and the [issue](https://github.com/xunit/xunit/issues/3475) created for that, I am trying to contribute to this repo for the first time.

Changes that were made are simple:

- Added an overload method for Assert.All with an extra `bool` parameter
- Added an overload method for Assert.AllAsync with an extra `bool` parameter

In both cases, the parameter is called `throwIfEmpty` which will throw an `AllException` if the parameter is set to true and the collection is empty.

This would kind of allow users to run 3 asserts into 1: `NotNull`, `NotEmpty`, `All` for any collection they're testing against.

I am open for suggestions if there's anything I've done wrong or different from code guidelines. 