### PR TITLE
Fix circular init in AOT equality comparer causing NRE on Mono

### DIFF
--- a/Sdk/AssertEqualityComparer_aot.cs
+++ b/Sdk/AssertEqualityComparer_aot.cs
@@ -18,13 +18,18 @@ namespace Xunit.Sdk
 {
 	partial class AssertEqualityComparer
 	{
-		static readonly IEqualityComparer defaultComparer = new AssertEqualityComparerAdapter<object>(new AssertEqualityComparer<object>());
-
+		// Create a new instance each call (matching the non-AOT/reflection path behavior)
+		// rather than caching in a static field. A cached static field causes a circular
+		// static initialization dependency: the field initializer triggers
+		// AssertEqualityComparer<object>'s static initializer, which reads the field back
+		// via GetDefaultInnerComparer before it has been assigned. On Mono/WASM, this
+		// causes DefaultInnerComparer to be permanently null, leading to
+		// NullReferenceException when comparing value types via IStructuralEquatable.
 		internal static IEqualityComparer GetDefaultComparer(Type _) =>
-			defaultComparer;
+			new AssertEqualityComparerAdapter<object>(new AssertEqualityComparer<object>());
 
 		internal static IEqualityComparer GetDefaultInnerComparer(Type _) =>
-			defaultComparer;
+			new AssertEqualityComparerAdapter<object>(new AssertEqualityComparer<object>());
 	}
 
 	partial class AssertEqualityComparer<T>


### PR DESCRIPTION
The `defaultComparer` field in `AssertEqualityComparer` (AOT path) eagerly creates `AssertEqualityComparerAdapter<object>`, which triggers `AssertEqualityComparer<object>`'s static initializer. That initializer reads `defaultComparer` back via `GetDefaultInnerComparer` before the field has been assigned. On Mono/WASM this results in `DefaultInnerComparer` being permanently null, leading to `NullReferenceException` when comparing value types via `IStructuralEquatable`.

Fix by creating a new instance on each call, matching the non-AOT reflection path behavior.

Port of dotnet/arcade#16615